### PR TITLE
test: add e2e tests with Playwright

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,20 +1,14 @@
 {
-    "env": {
-        "browser": true,
-        "es2021": true
-    },
-    "extends": [
-        "eslint:recommended",
-        "plugin:@typescript-eslint/recommended"
-    ],
-    "parser": "@typescript-eslint/parser",
-    "parserOptions": {
-        "ecmaVersion": "latest",
-        "sourceType": "module"
-    },
-    "plugins": [
-        "@typescript-eslint"
-    ],
-    "rules": {
-    }
+  "env": {
+    "browser": true,
+    "es2021": true
+  },
+  "extends": ["eslint:recommended", "plugin:@typescript-eslint/recommended"],
+  "parser": "@typescript-eslint/parser",
+  "parserOptions": {
+    "ecmaVersion": "latest",
+    "sourceType": "module"
+  },
+  "plugins": ["@typescript-eslint"],
+  "rules": {}
 }

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -1,0 +1,27 @@
+name: Playwright Tests
+on:
+  push:
+    branches: [ main, master ]
+  pull_request:
+    branches: [ main, master ]
+jobs:
+  test:
+    timeout-minutes: 60
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - uses: actions/setup-node@v3
+      with:
+        node-version: 16
+    - name: Install dependencies
+      run: npm ci
+    - name: Install Playwright Browsers
+      run: npx playwright install --with-deps
+    - name: Run Playwright tests
+      run: npx playwright test
+    - uses: actions/upload-artifact@v3
+      if: always()
+      with:
+        name: playwright-report
+        path: playwright-report/
+        retention-days: 30

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -1,12 +1,12 @@
 name: Playwright Tests
 on:
   push:
-    branches: [ main, master ]
+    branches: [ main ]
   pull_request:
-    branches: [ main, master ]
+    branches: [ main ]
 jobs:
   test:
-    timeout-minutes: 60
+    timeout-minutes: 10
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -1,27 +1,27 @@
 name: Playwright Tests
 on:
   push:
-    branches: [ main ]
+    branches: [main]
   pull_request:
-    branches: [ main ]
+    branches: [main]
 jobs:
   test:
     timeout-minutes: 10
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
-    - uses: actions/setup-node@v3
-      with:
-        node-version: 16
-    - name: Install dependencies
-      run: npm ci
-    - name: Install Playwright Browsers
-      run: npx playwright install --with-deps
-    - name: Run Playwright tests
-      run: npx playwright test
-    - uses: actions/upload-artifact@v3
-      if: always()
-      with:
-        name: playwright-report
-        path: playwright-report/
-        retention-days: 30
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 16
+      - name: Install dependencies
+        run: npm ci
+      - name: Install Playwright Browsers
+        run: npx playwright install --with-deps
+      - name: Run Playwright tests
+        run: npx playwright test
+      - uses: actions/upload-artifact@v3
+        if: always()
+        with:
+          name: playwright-report
+          path: playwright-report/
+          retention-days: 30

--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,6 @@ dist-ssr
 *.njsproj
 *.sln
 *.sw?
+/test-results/
+/playwright-report/
+/playwright/.cache/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,8 @@
-
-
 ## [0.2.0](https://github.com/lorenzvanherwaarden/datetime-web-component/compare/v0.1.9...v0.2.0) (2023-01-06)
-
 
 ### Features
 
-* allow to block certain dates ([#11](https://github.com/lorenzvanherwaarden/datetime-web-component/issues/11)) ([f4c98f4](https://github.com/lorenzvanherwaarden/datetime-web-component/commit/f4c98f468d3d3879c2068fe7657fa928d0e1c832))
+- allow to block certain dates ([#11](https://github.com/lorenzvanherwaarden/datetime-web-component/issues/11)) ([f4c98f4](https://github.com/lorenzvanherwaarden/datetime-web-component/commit/f4c98f468d3d3879c2068fe7657fa928d0e1c832))
 
 ### [0.1.9](https://github.com/lorenzvanherwaarden/datetime-web-component/compare/v0.1.7...v0.1.9) (2023-01-05)
 
@@ -17,10 +14,9 @@
 
 ### [0.1.4](https://github.com/lorenzvanherwaarden/datetime-web-component/compare/v0.1.3...v0.1.4) (2022-08-17)
 
-
 ### Bug Fixes
 
-* use correct attribute naming ([f64cc6e](https://github.com/lorenzvanherwaarden/datetime-web-component/commit/f64cc6e82e757bba38f1391cacf14a01c368b4cf))
+- use correct attribute naming ([f64cc6e](https://github.com/lorenzvanherwaarden/datetime-web-component/commit/f64cc6e82e757bba38f1391cacf14a01c368b4cf))
 
 ### [0.1.3](https://github.com/lorenzvanherwaarden/datetime-web-component/compare/v0.1.2...v0.1.3) (2022-08-15)
 
@@ -30,19 +26,17 @@
 
 ## 0.1.0 (2022-08-15)
 
-
 ### Features
 
-* add dark mode colors ([d8171a2](https://github.com/lorenzvanherwaarden/datetime-web-component/commit/d8171a259f78e9e5c603dd4b426e4b9aa10b5663))
-* add month and year header ([bff048f](https://github.com/lorenzvanherwaarden/datetime-web-component/commit/bff048f2dacdb125413a39d0a4223a9cfd49f47a))
-* add more style variables ([26d6d30](https://github.com/lorenzvanherwaarden/datetime-web-component/commit/26d6d30fdc314b33c365320081d6d9da0a0530ad))
-* add year select view ([57be192](https://github.com/lorenzvanherwaarden/datetime-web-component/commit/57be192a3a1d04af6bd9c0f3164cbfdbbee2a403))
-* allow time input ([131ffce](https://github.com/lorenzvanherwaarden/datetime-web-component/commit/131ffce4f682c81a14b6e66627008671986581e8))
-* create cells and dispatch events ([5956037](https://github.com/lorenzvanherwaarden/datetime-web-component/commit/5956037a4468ac3a8ad9bd6d5abe8d96d5211679))
-* setup click listeners and first property handles ([7171f39](https://github.com/lorenzvanherwaarden/datetime-web-component/commit/7171f394ad7e0ebb4e2c561e54c3986a0be28cf7))
-
+- add dark mode colors ([d8171a2](https://github.com/lorenzvanherwaarden/datetime-web-component/commit/d8171a259f78e9e5c603dd4b426e4b9aa10b5663))
+- add month and year header ([bff048f](https://github.com/lorenzvanherwaarden/datetime-web-component/commit/bff048f2dacdb125413a39d0a4223a9cfd49f47a))
+- add more style variables ([26d6d30](https://github.com/lorenzvanherwaarden/datetime-web-component/commit/26d6d30fdc314b33c365320081d6d9da0a0530ad))
+- add year select view ([57be192](https://github.com/lorenzvanherwaarden/datetime-web-component/commit/57be192a3a1d04af6bd9c0f3164cbfdbbee2a403))
+- allow time input ([131ffce](https://github.com/lorenzvanherwaarden/datetime-web-component/commit/131ffce4f682c81a14b6e66627008671986581e8))
+- create cells and dispatch events ([5956037](https://github.com/lorenzvanherwaarden/datetime-web-component/commit/5956037a4468ac3a8ad9bd6d5abe8d96d5211679))
+- setup click listeners and first property handles ([7171f39](https://github.com/lorenzvanherwaarden/datetime-web-component/commit/7171f394ad7e0ebb4e2c561e54c3986a0be28cf7))
 
 ### Bug Fixes
 
-* handle months that are zero ([1386574](https://github.com/lorenzvanherwaarden/datetime-web-component/commit/138657416d7fb61d2bdf973252f23737357f8c9c))
-* use utc time ([24cfb00](https://github.com/lorenzvanherwaarden/datetime-web-component/commit/24cfb007d87b33062af72e5c4d15033342b9ac56))
+- handle months that are zero ([1386574](https://github.com/lorenzvanherwaarden/datetime-web-component/commit/138657416d7fb61d2bdf973252f23737357f8c9c))
+- use utc time ([24cfb00](https://github.com/lorenzvanherwaarden/datetime-web-component/commit/24cfb007d87b33062af72e5c4d15033342b9ac56))

--- a/index.html
+++ b/index.html
@@ -63,7 +63,7 @@
         --input-border-radius: 6px;
       } */
     </style>
-    <input id="input" type="text" />
+    <input id="input" data-test-id="input" type="text" />
     <datetime-web-component value="2022-12-07T12:12:03.000Z" show-seconds />
   </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -63,7 +63,7 @@
         --input-border-radius: 6px;
       } */
     </style>
-    <input id="input" data-test-id="input" type="text" />
+    <input id="input" type="text" />
     <datetime-web-component value="2022-12-07T12:12:03.000Z" show-seconds />
   </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -63,7 +63,7 @@
         --input-border-radius: 6px;
       } */
     </style>
-    <input id="input" type="text" />
+    <input id="input" type="text" data-testid="input" />
     <datetime-web-component value="2022-12-07T12:12:03.000Z" show-seconds />
   </body>
 </html>

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,14 +11,17 @@
         "@floating-ui/dom": "^1.0.0"
       },
       "devDependencies": {
+        "@playwright/test": "^1.29.2",
         "@release-it/conventional-changelog": "^5.0.0",
         "@typescript-eslint/eslint-plugin": "^5.48.0",
         "@typescript-eslint/parser": "^5.48.0",
         "eslint": "^8.31.0",
+        "playwright": "^1.29.2",
         "prettier": "2.8.1",
         "release-it": "^15.6.0",
         "typescript": "^4.9.3",
-        "vite": "^4.0.0"
+        "vite": "^4.0.0",
+        "vitest": "^0.26.3"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -777,6 +780,22 @@
         "@octokit/openapi-types": "^14.0.0"
       }
     },
+    "node_modules/@playwright/test": {
+      "version": "1.29.2",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.29.2.tgz",
+      "integrity": "sha512-+3/GPwOgcoF0xLz/opTnahel1/y42PdcgZ4hs+BZGIUjtmEFSXGg+nFoaH3NSmuc7a6GSFwXDJ5L7VXpqzigNg==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*",
+        "playwright-core": "1.29.2"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "node_modules/@pnpm/network.ca-file": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@pnpm/network.ca-file/-/network.ca-file-1.0.1.tgz",
@@ -852,6 +871,21 @@
         "node": ">= 6"
       }
     },
+    "node_modules/@types/chai": {
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.3.4.tgz",
+      "integrity": "sha512-KnRanxnpfpjUTqTCXslZSEdLfXExwgNxYPdiO2WGUj8+HDjFi8R3k5RVKPeSCzLjCcshCAtVO2QBbVuAV4kTnw==",
+      "dev": true
+    },
+    "node_modules/@types/chai-subset": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@types/chai-subset/-/chai-subset-1.3.3.tgz",
+      "integrity": "sha512-frBecisrNGz+F4T6bcc+NLeolfiojh5FxW2klu669+8BARtyQv2C/GkNW6FUodVe4BroGMP/wER/YDGc7rEllw==",
+      "dev": true,
+      "dependencies": {
+        "@types/chai": "*"
+      }
+    },
     "node_modules/@types/json-schema": {
       "version": "7.0.11",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.11.tgz",
@@ -868,9 +902,7 @@
       "version": "18.6.4",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-18.6.4.tgz",
       "integrity": "sha512-I4BD3L+6AWiUobfxZ49DlU43gtI+FTHSv9pE2Zekg6KjMpre4ByusaljW3vYSLJrvQ1ck1hUaeVu8HVlY3vzHg==",
-      "dev": true,
-      "optional": true,
-      "peer": true
+      "dev": true
     },
     "node_modules/@types/normalize-package-data": {
       "version": "2.4.1",
@@ -1072,9 +1104,9 @@
       }
     },
     "node_modules/acorn": {
-      "version": "8.8.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.0.tgz",
-      "integrity": "sha512-QOxyigPVrpZ2GXT+PFyZTl6TtOFc5egxHIP9IlQ+RbupQuX4RkT/Bee4/kQuC02Xkzg84JcT7oLYtDIQxp+v7w==",
+      "version": "8.8.1",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.1.tgz",
+      "integrity": "sha512-7zFpHzhnqYKrkYdUjF1HI1bzd0VygEGX8lFk4k5zVMqHEoES+P+7TKI+EvLO9WVMJ8eekdO0aDEK044xTXwPPA==",
       "dev": true,
       "bin": {
         "acorn": "bin/acorn"
@@ -1262,6 +1294,15 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
+      "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
+      "dev": true,
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/ast-types": {
@@ -1548,6 +1589,24 @@
         "node": ">=8"
       }
     },
+    "node_modules/chai": {
+      "version": "4.3.7",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-4.3.7.tgz",
+      "integrity": "sha512-HLnAzZ2iupm25PlN0xFreAlBA5zaBSv3og0DdeGA4Ar6h6rJ3A0rolRUKJhSF2V10GZKDgWF/VmAEsNWjCRB+A==",
+      "dev": true,
+      "dependencies": {
+        "assertion-error": "^1.1.0",
+        "check-error": "^1.0.2",
+        "deep-eql": "^4.1.2",
+        "get-func-name": "^2.0.0",
+        "loupe": "^2.3.1",
+        "pathval": "^1.1.1",
+        "type-detect": "^4.0.5"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -1569,6 +1628,15 @@
       "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
       "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
       "dev": true
+    },
+    "node_modules/check-error": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.2.tgz",
+      "integrity": "sha512-BrgHpW9NURQgzoNyjfq0Wu6VFO6D7IZEmJNdtgNqpzGG8RuNFHt2jQxWlAs4HMe119chBnv+34syEZtc6IhLtA==",
+      "dev": true,
+      "engines": {
+        "node": "*"
+      }
     },
     "node_modules/ci-info": {
       "version": "3.3.2",
@@ -2194,6 +2262,18 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/deep-eql": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-4.1.3.tgz",
+      "integrity": "sha512-WaEtAOpRA1MQ0eohqZjpGD8zdI0Ovsm8mmFhaDN8dvDZzyoUMcYDnf5Y6iu7HTXxf8JDS23qWa4a+hKCDyOPzw==",
+      "dev": true,
+      "dependencies": {
+        "type-detect": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/deep-extend": {
@@ -3160,6 +3240,15 @@
       "dev": true,
       "engines": {
         "node": "6.* || 8.* || >= 10.*"
+      }
+    },
+    "node_modules/get-func-name": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.0.tgz",
+      "integrity": "sha512-Hm0ixYtaSZ/V7C8FJrtZIuBBI+iSgL+1Aq82zSu8VQNB4S3Gk8e7Qs3VwBDJAhmRZcFqkl3tQu36g/Foh5I5ig==",
+      "dev": true,
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/get-intrinsic": {
@@ -4488,6 +4577,12 @@
       "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==",
       "dev": true
     },
+    "node_modules/jsonc-parser": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.2.0.tgz",
+      "integrity": "sha512-gfFQZrcTc8CnKXp6Y4/CBT3fTc0OVuDofpre4aEeEpSBPV5X5v4+Vmx+8snU7RLPrNHPKSgLxGo9YuQzz20o+w==",
+      "dev": true
+    },
     "node_modules/jsonfile": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
@@ -4611,6 +4706,18 @@
         "node": ">=4"
       }
     },
+    "node_modules/local-pkg": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/local-pkg/-/local-pkg-0.4.2.tgz",
+      "integrity": "sha512-mlERgSPrbxU3BP4qBqAvvwlgW4MTg78iwJdGGnv7kibKjWcJksrG3t6LB5lXI93wXRDvG4NpUgJFmTG4T6rdrg==",
+      "dev": true,
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
     "node_modules/locate-path": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
@@ -4670,6 +4777,15 @@
       },
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/loupe": {
+      "version": "2.3.6",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-2.3.6.tgz",
+      "integrity": "sha512-RaPMZKiMy8/JruncMU5Bt6na1eftNoo++R4Y+N2FrxkDVTrGvcyzFTsaGif4QTeKESheMGegbhw6iUAq+5A8zA==",
+      "dev": true,
+      "dependencies": {
+        "get-func-name": "^2.0.0"
       }
     },
     "node_modules/lowercase-keys": {
@@ -5008,6 +5124,24 @@
       "engines": {
         "node": ">= 6"
       }
+    },
+    "node_modules/mlly": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/mlly/-/mlly-1.0.0.tgz",
+      "integrity": "sha512-QL108Hwt+u9bXdWgOI0dhzZfACovn5Aen4Xvc8Jasd9ouRH4NjnrXEiyP3nVvJo91zPlYjVRckta0Nt2zfoR6g==",
+      "dev": true,
+      "dependencies": {
+        "acorn": "^8.8.1",
+        "pathe": "^1.0.0",
+        "pkg-types": "^1.0.0",
+        "ufo": "^1.0.0"
+      }
+    },
+    "node_modules/mlly/node_modules/pathe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.0.0.tgz",
+      "integrity": "sha512-nPdMG0Pd09HuSsr7QOKUXO2Jr9eqaDiZvDwdyIhNG5SHYujkQHYKDfGQkulBxvbDHz8oHLsTgKN86LSwYzSHAg==",
+      "dev": true
     },
     "node_modules/modify-values": {
       "version": "1.0.1",
@@ -5558,6 +5692,21 @@
         "node": ">=8"
       }
     },
+    "node_modules/pathe": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-0.2.0.tgz",
+      "integrity": "sha512-sTitTPYnn23esFR3RlqYBWn4c45WGeLcsKzQiUpXJAyfcWkolvlYpV8FLo7JishK946oQwMFUCHXQ9AjGPKExw==",
+      "dev": true
+    },
+    "node_modules/pathval": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.1.tgz",
+      "integrity": "sha512-Dp6zGqpTdETdR63lehJYPeIOqpiNBNtc7BpWSLrOje7UaIsE5aY92r/AunQA7rsXvet3lrJ3JnZX29UPTKXyKQ==",
+      "dev": true,
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/picocolors": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
@@ -5583,6 +5732,51 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/pkg-types": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-1.0.1.tgz",
+      "integrity": "sha512-jHv9HB+Ho7dj6ItwppRDDl0iZRYBD0jsakHXtFgoLr+cHSF6xC+QL54sJmWxyGxOLYSHm0afhXhXcQDQqH9z8g==",
+      "dev": true,
+      "dependencies": {
+        "jsonc-parser": "^3.2.0",
+        "mlly": "^1.0.0",
+        "pathe": "^1.0.0"
+      }
+    },
+    "node_modules/pkg-types/node_modules/pathe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.0.0.tgz",
+      "integrity": "sha512-nPdMG0Pd09HuSsr7QOKUXO2Jr9eqaDiZvDwdyIhNG5SHYujkQHYKDfGQkulBxvbDHz8oHLsTgKN86LSwYzSHAg==",
+      "dev": true
+    },
+    "node_modules/playwright": {
+      "version": "1.29.2",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.29.2.tgz",
+      "integrity": "sha512-hKBYJUtdmYzcjdhYDkP9WGtORwwZBBKAW8+Lz7sr0ZMxtJr04ASXVzH5eBWtDkdb0c3LLFsehfPBTRfvlfKJOA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "dependencies": {
+        "playwright-core": "1.29.2"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.29.2",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.29.2.tgz",
+      "integrity": "sha512-94QXm4PMgFoHAhlCuoWyaBYKb92yOcGVHdQLoxQ7Wjlc7Flg4aC/jbFW7xMR52OfXMVkWicue4WXE7QEegbIRA==",
+      "dev": true,
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/postcss": {
@@ -6540,6 +6734,16 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/source-map-support": {
+      "version": "0.5.21",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
+      "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
+      "dev": true,
+      "dependencies": {
+        "buffer-from": "^1.0.0",
+        "source-map": "^0.6.0"
+      }
+    },
     "node_modules/spdx-correct": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.1.1.tgz",
@@ -6740,6 +6944,18 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/strip-literal": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/strip-literal/-/strip-literal-1.0.0.tgz",
+      "integrity": "sha512-5o4LsH1lzBzO9UFH63AJ2ad2/S2AVx6NtjOcaz+VTT2h1RiRvbipW72z8M/lxEhcPHDBQwpDrnTF7sXy/7OwCQ==",
+      "dev": true,
+      "dependencies": {
+        "acorn": "^8.8.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
     "node_modules/supports-color": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -6792,6 +7008,30 @@
       "dev": true,
       "dependencies": {
         "readable-stream": "3"
+      }
+    },
+    "node_modules/tinybench": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.3.1.tgz",
+      "integrity": "sha512-hGYWYBMPr7p4g5IarQE7XhlyWveh1EKhy4wUBS1LrHXCKYgvz+4/jCqgmJqZxxldesn05vccrtME2RLLZNW7iA==",
+      "dev": true
+    },
+    "node_modules/tinypool": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-0.3.0.tgz",
+      "integrity": "sha512-NX5KeqHOBZU6Bc0xj9Vr5Szbb1j8tUHIeD18s41aDJaPeC5QTdEhK0SpdpUrZlj2nv5cctNcSjaKNanXlfcVEQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-1.0.2.tgz",
+      "integrity": "sha512-bSGlgwLBYf7PnUsQ6WOc6SJ3pGOcd+d8AA6EUnLDDM0kWEstC1JIlSZA3UNliDXhd9ABoS7hiRBDCu+XP/sf1Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/tmp": {
@@ -6875,6 +7115,15 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/type-detect": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
+      "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/type-fest": {
       "version": "0.20.2",
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
@@ -6928,6 +7177,12 @@
       "engines": {
         "node": ">=4.2.0"
       }
+    },
+    "node_modules/ufo": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.0.1.tgz",
+      "integrity": "sha512-boAm74ubXHY7KJQZLlXrtMz52qFvpsbOxDcZOnw/Wf+LS4Mmyu7JxmzD4tDLtUQtmZECypJ0FrCz4QIe6dvKRA==",
+      "dev": true
     },
     "node_modules/uglify-js": {
       "version": "3.16.3",
@@ -7115,6 +7370,85 @@
           "optional": true
         },
         "terser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite-node": {
+      "version": "0.26.3",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-0.26.3.tgz",
+      "integrity": "sha512-Te2bq0Bfvq6XiO718I+1EinMjpNYKws6SNHKOmVbILAQimKoZKDd+IZLlkaYcBXPpK3HFe2U80k8Zw+m3w/a2w==",
+      "dev": true,
+      "dependencies": {
+        "debug": "^4.3.4",
+        "mlly": "^1.0.0",
+        "pathe": "^0.2.0",
+        "source-map": "^0.6.1",
+        "source-map-support": "^0.5.21",
+        "vite": "^3.0.0 || ^4.0.0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": ">=v14.16.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "0.26.3",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-0.26.3.tgz",
+      "integrity": "sha512-FmHxU9aUCxTi23keF3vxb/Qp0lYXaaJ+jRLGOUmMS3qVTOJvgGE+f1VArupA6pEhaG2Ans4X+zV9dqM5WISMbg==",
+      "dev": true,
+      "dependencies": {
+        "@types/chai": "^4.3.4",
+        "@types/chai-subset": "^1.3.3",
+        "@types/node": "*",
+        "acorn": "^8.8.1",
+        "acorn-walk": "^8.2.0",
+        "chai": "^4.3.7",
+        "debug": "^4.3.4",
+        "local-pkg": "^0.4.2",
+        "source-map": "^0.6.1",
+        "strip-literal": "^1.0.0",
+        "tinybench": "^2.3.1",
+        "tinypool": "^0.3.0",
+        "tinyspy": "^1.0.2",
+        "vite": "^3.0.0 || ^4.0.0",
+        "vite-node": "0.26.3"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": ">=v14.16.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@vitest/browser": "*",
+        "@vitest/ui": "*",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
           "optional": true
         }
       }
@@ -8013,6 +8347,16 @@
         "@octokit/openapi-types": "^14.0.0"
       }
     },
+    "@playwright/test": {
+      "version": "1.29.2",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.29.2.tgz",
+      "integrity": "sha512-+3/GPwOgcoF0xLz/opTnahel1/y42PdcgZ4hs+BZGIUjtmEFSXGg+nFoaH3NSmuc7a6GSFwXDJ5L7VXpqzigNg==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*",
+        "playwright-core": "1.29.2"
+      }
+    },
     "@pnpm/network.ca-file": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@pnpm/network.ca-file/-/network.ca-file-1.0.1.tgz",
@@ -8064,6 +8408,21 @@
       "integrity": "sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw==",
       "dev": true
     },
+    "@types/chai": {
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.3.4.tgz",
+      "integrity": "sha512-KnRanxnpfpjUTqTCXslZSEdLfXExwgNxYPdiO2WGUj8+HDjFi8R3k5RVKPeSCzLjCcshCAtVO2QBbVuAV4kTnw==",
+      "dev": true
+    },
+    "@types/chai-subset": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@types/chai-subset/-/chai-subset-1.3.3.tgz",
+      "integrity": "sha512-frBecisrNGz+F4T6bcc+NLeolfiojh5FxW2klu669+8BARtyQv2C/GkNW6FUodVe4BroGMP/wER/YDGc7rEllw==",
+      "dev": true,
+      "requires": {
+        "@types/chai": "*"
+      }
+    },
     "@types/json-schema": {
       "version": "7.0.11",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.11.tgz",
@@ -8080,9 +8439,7 @@
       "version": "18.6.4",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-18.6.4.tgz",
       "integrity": "sha512-I4BD3L+6AWiUobfxZ49DlU43gtI+FTHSv9pE2Zekg6KjMpre4ByusaljW3vYSLJrvQ1ck1hUaeVu8HVlY3vzHg==",
-      "dev": true,
-      "optional": true,
-      "peer": true
+      "dev": true
     },
     "@types/normalize-package-data": {
       "version": "2.4.1",
@@ -8195,9 +8552,9 @@
       }
     },
     "acorn": {
-      "version": "8.8.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.0.tgz",
-      "integrity": "sha512-QOxyigPVrpZ2GXT+PFyZTl6TtOFc5egxHIP9IlQ+RbupQuX4RkT/Bee4/kQuC02Xkzg84JcT7oLYtDIQxp+v7w==",
+      "version": "8.8.1",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.1.tgz",
+      "integrity": "sha512-7zFpHzhnqYKrkYdUjF1HI1bzd0VygEGX8lFk4k5zVMqHEoES+P+7TKI+EvLO9WVMJ8eekdO0aDEK044xTXwPPA==",
       "dev": true
     },
     "acorn-jsx": {
@@ -8335,6 +8692,12 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
       "integrity": "sha512-3CYzex9M9FGQjCGMGyi6/31c8GJbgb0qGyrx5HWxPd0aCwh4cB2YjMb2Xf9UuoogrMrlO9cTqnB5rI5GHZTcUA==",
+      "dev": true
+    },
+    "assertion-error": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
+      "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
       "dev": true
     },
     "ast-types": {
@@ -8536,6 +8899,21 @@
         }
       }
     },
+    "chai": {
+      "version": "4.3.7",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-4.3.7.tgz",
+      "integrity": "sha512-HLnAzZ2iupm25PlN0xFreAlBA5zaBSv3og0DdeGA4Ar6h6rJ3A0rolRUKJhSF2V10GZKDgWF/VmAEsNWjCRB+A==",
+      "dev": true,
+      "requires": {
+        "assertion-error": "^1.1.0",
+        "check-error": "^1.0.2",
+        "deep-eql": "^4.1.2",
+        "get-func-name": "^2.0.0",
+        "loupe": "^2.3.1",
+        "pathval": "^1.1.1",
+        "type-detect": "^4.0.5"
+      }
+    },
     "chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -8550,6 +8928,12 @@
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
       "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
+      "dev": true
+    },
+    "check-error": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.2.tgz",
+      "integrity": "sha512-BrgHpW9NURQgzoNyjfq0Wu6VFO6D7IZEmJNdtgNqpzGG8RuNFHt2jQxWlAs4HMe119chBnv+34syEZtc6IhLtA==",
       "dev": true
     },
     "ci-info": {
@@ -9026,6 +9410,15 @@
           "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
           "dev": true
         }
+      }
+    },
+    "deep-eql": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-4.1.3.tgz",
+      "integrity": "sha512-WaEtAOpRA1MQ0eohqZjpGD8zdI0Ovsm8mmFhaDN8dvDZzyoUMcYDnf5Y6iu7HTXxf8JDS23qWa4a+hKCDyOPzw==",
+      "dev": true,
+      "requires": {
+        "type-detect": "^4.0.0"
       }
     },
     "deep-extend": {
@@ -9758,6 +10151,12 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
       "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "dev": true
+    },
+    "get-func-name": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.0.tgz",
+      "integrity": "sha512-Hm0ixYtaSZ/V7C8FJrtZIuBBI+iSgL+1Aq82zSu8VQNB4S3Gk8e7Qs3VwBDJAhmRZcFqkl3tQu36g/Foh5I5ig==",
       "dev": true
     },
     "get-intrinsic": {
@@ -10710,6 +11109,12 @@
       "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==",
       "dev": true
     },
+    "jsonc-parser": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.2.0.tgz",
+      "integrity": "sha512-gfFQZrcTc8CnKXp6Y4/CBT3fTc0OVuDofpre4aEeEpSBPV5X5v4+Vmx+8snU7RLPrNHPKSgLxGo9YuQzz20o+w==",
+      "dev": true
+    },
     "jsonfile": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
@@ -10805,6 +11210,12 @@
         }
       }
     },
+    "local-pkg": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/local-pkg/-/local-pkg-0.4.2.tgz",
+      "integrity": "sha512-mlERgSPrbxU3BP4qBqAvvwlgW4MTg78iwJdGGnv7kibKjWcJksrG3t6LB5lXI93wXRDvG4NpUgJFmTG4T6rdrg==",
+      "dev": true
+    },
     "locate-path": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
@@ -10848,6 +11259,15 @@
           "integrity": "sha512-ree3Gqw/nazQAPuJJEy+avdl7QfZMcUvmHIKgEZkGL+xOBzRvup5Hxo6LHuMceSxOabuJLJm5Yp/92R9eMmMvA==",
           "dev": true
         }
+      }
+    },
+    "loupe": {
+      "version": "2.3.6",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-2.3.6.tgz",
+      "integrity": "sha512-RaPMZKiMy8/JruncMU5Bt6na1eftNoo++R4Y+N2FrxkDVTrGvcyzFTsaGif4QTeKESheMGegbhw6iUAq+5A8zA==",
+      "dev": true,
+      "requires": {
+        "get-func-name": "^2.0.0"
       }
     },
     "lowercase-keys": {
@@ -11089,6 +11509,26 @@
         "arrify": "^1.0.1",
         "is-plain-obj": "^1.1.0",
         "kind-of": "^6.0.3"
+      }
+    },
+    "mlly": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/mlly/-/mlly-1.0.0.tgz",
+      "integrity": "sha512-QL108Hwt+u9bXdWgOI0dhzZfACovn5Aen4Xvc8Jasd9ouRH4NjnrXEiyP3nVvJo91zPlYjVRckta0Nt2zfoR6g==",
+      "dev": true,
+      "requires": {
+        "acorn": "^8.8.1",
+        "pathe": "^1.0.0",
+        "pkg-types": "^1.0.0",
+        "ufo": "^1.0.0"
+      },
+      "dependencies": {
+        "pathe": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.0.0.tgz",
+          "integrity": "sha512-nPdMG0Pd09HuSsr7QOKUXO2Jr9eqaDiZvDwdyIhNG5SHYujkQHYKDfGQkulBxvbDHz8oHLsTgKN86LSwYzSHAg==",
+          "dev": true
+        }
       }
     },
     "modify-values": {
@@ -11470,6 +11910,18 @@
       "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
       "dev": true
     },
+    "pathe": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-0.2.0.tgz",
+      "integrity": "sha512-sTitTPYnn23esFR3RlqYBWn4c45WGeLcsKzQiUpXJAyfcWkolvlYpV8FLo7JishK946oQwMFUCHXQ9AjGPKExw==",
+      "dev": true
+    },
+    "pathval": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.1.tgz",
+      "integrity": "sha512-Dp6zGqpTdETdR63lehJYPeIOqpiNBNtc7BpWSLrOje7UaIsE5aY92r/AunQA7rsXvet3lrJ3JnZX29UPTKXyKQ==",
+      "dev": true
+    },
     "picocolors": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
@@ -11486,6 +11938,40 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
       "integrity": "sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==",
+      "dev": true
+    },
+    "pkg-types": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-1.0.1.tgz",
+      "integrity": "sha512-jHv9HB+Ho7dj6ItwppRDDl0iZRYBD0jsakHXtFgoLr+cHSF6xC+QL54sJmWxyGxOLYSHm0afhXhXcQDQqH9z8g==",
+      "dev": true,
+      "requires": {
+        "jsonc-parser": "^3.2.0",
+        "mlly": "^1.0.0",
+        "pathe": "^1.0.0"
+      },
+      "dependencies": {
+        "pathe": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.0.0.tgz",
+          "integrity": "sha512-nPdMG0Pd09HuSsr7QOKUXO2Jr9eqaDiZvDwdyIhNG5SHYujkQHYKDfGQkulBxvbDHz8oHLsTgKN86LSwYzSHAg==",
+          "dev": true
+        }
+      }
+    },
+    "playwright": {
+      "version": "1.29.2",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.29.2.tgz",
+      "integrity": "sha512-hKBYJUtdmYzcjdhYDkP9WGtORwwZBBKAW8+Lz7sr0ZMxtJr04ASXVzH5eBWtDkdb0c3LLFsehfPBTRfvlfKJOA==",
+      "dev": true,
+      "requires": {
+        "playwright-core": "1.29.2"
+      }
+    },
+    "playwright-core": {
+      "version": "1.29.2",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.29.2.tgz",
+      "integrity": "sha512-94QXm4PMgFoHAhlCuoWyaBYKb92yOcGVHdQLoxQ7Wjlc7Flg4aC/jbFW7xMR52OfXMVkWicue4WXE7QEegbIRA==",
       "dev": true
     },
     "postcss": {
@@ -12162,6 +12648,16 @@
       "integrity": "sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==",
       "dev": true
     },
+    "source-map-support": {
+      "version": "0.5.21",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
+      "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
+      "dev": true,
+      "requires": {
+        "buffer-from": "^1.0.0",
+        "source-map": "^0.6.0"
+      }
+    },
     "spdx-correct": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.1.1.tgz",
@@ -12313,6 +12809,15 @@
       "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
       "dev": true
     },
+    "strip-literal": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/strip-literal/-/strip-literal-1.0.0.tgz",
+      "integrity": "sha512-5o4LsH1lzBzO9UFH63AJ2ad2/S2AVx6NtjOcaz+VTT2h1RiRvbipW72z8M/lxEhcPHDBQwpDrnTF7sXy/7OwCQ==",
+      "dev": true,
+      "requires": {
+        "acorn": "^8.8.1"
+      }
+    },
     "supports-color": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -12354,6 +12859,24 @@
       "requires": {
         "readable-stream": "3"
       }
+    },
+    "tinybench": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.3.1.tgz",
+      "integrity": "sha512-hGYWYBMPr7p4g5IarQE7XhlyWveh1EKhy4wUBS1LrHXCKYgvz+4/jCqgmJqZxxldesn05vccrtME2RLLZNW7iA==",
+      "dev": true
+    },
+    "tinypool": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-0.3.0.tgz",
+      "integrity": "sha512-NX5KeqHOBZU6Bc0xj9Vr5Szbb1j8tUHIeD18s41aDJaPeC5QTdEhK0SpdpUrZlj2nv5cctNcSjaKNanXlfcVEQ==",
+      "dev": true
+    },
+    "tinyspy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-1.0.2.tgz",
+      "integrity": "sha512-bSGlgwLBYf7PnUsQ6WOc6SJ3pGOcd+d8AA6EUnLDDM0kWEstC1JIlSZA3UNliDXhd9ABoS7hiRBDCu+XP/sf1Q==",
+      "dev": true
     },
     "tmp": {
       "version": "0.0.33",
@@ -12415,6 +12938,12 @@
         "prelude-ls": "^1.2.1"
       }
     },
+    "type-detect": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
+      "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
+      "dev": true
+    },
     "type-fest": {
       "version": "0.20.2",
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
@@ -12451,6 +12980,12 @@
       "version": "4.9.4",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.4.tgz",
       "integrity": "sha512-Uz+dTXYzxXXbsFpM86Wh3dKCxrQqUcVMxwU54orwlJjOpO3ao8L7j5lH+dWfTwgCwIuM9GQ2kvVotzYJMXTBZg==",
+      "dev": true
+    },
+    "ufo": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.0.1.tgz",
+      "integrity": "sha512-boAm74ubXHY7KJQZLlXrtMz52qFvpsbOxDcZOnw/Wf+LS4Mmyu7JxmzD4tDLtUQtmZECypJ0FrCz4QIe6dvKRA==",
       "dev": true
     },
     "uglify-js": {
@@ -12571,6 +13106,43 @@
         "postcss": "^8.4.20",
         "resolve": "^1.22.1",
         "rollup": "^3.7.0"
+      }
+    },
+    "vite-node": {
+      "version": "0.26.3",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-0.26.3.tgz",
+      "integrity": "sha512-Te2bq0Bfvq6XiO718I+1EinMjpNYKws6SNHKOmVbILAQimKoZKDd+IZLlkaYcBXPpK3HFe2U80k8Zw+m3w/a2w==",
+      "dev": true,
+      "requires": {
+        "debug": "^4.3.4",
+        "mlly": "^1.0.0",
+        "pathe": "^0.2.0",
+        "source-map": "^0.6.1",
+        "source-map-support": "^0.5.21",
+        "vite": "^3.0.0 || ^4.0.0"
+      }
+    },
+    "vitest": {
+      "version": "0.26.3",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-0.26.3.tgz",
+      "integrity": "sha512-FmHxU9aUCxTi23keF3vxb/Qp0lYXaaJ+jRLGOUmMS3qVTOJvgGE+f1VArupA6pEhaG2Ans4X+zV9dqM5WISMbg==",
+      "dev": true,
+      "requires": {
+        "@types/chai": "^4.3.4",
+        "@types/chai-subset": "^1.3.3",
+        "@types/node": "*",
+        "acorn": "^8.8.1",
+        "acorn-walk": "^8.2.0",
+        "chai": "^4.3.7",
+        "debug": "^4.3.4",
+        "local-pkg": "^0.4.2",
+        "source-map": "^0.6.1",
+        "strip-literal": "^1.0.0",
+        "tinybench": "^2.3.1",
+        "tinypool": "^0.3.0",
+        "tinyspy": "^1.0.2",
+        "vite": "^3.0.0 || ^4.0.0",
+        "vite-node": "0.26.3"
       }
     },
     "vm2": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,8 @@
       "name": "datetime-web-component",
       "version": "0.1.6",
       "dependencies": {
-        "@floating-ui/dom": "^1.0.0"
+        "@floating-ui/dom": "^1.0.0",
+        "playwright": "^1.29.2"
       },
       "devDependencies": {
         "@playwright/test": "^1.29.2",
@@ -5600,11 +5601,25 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/playwright": {
+      "version": "1.29.2",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.29.2.tgz",
+      "integrity": "sha512-hKBYJUtdmYzcjdhYDkP9WGtORwwZBBKAW8+Lz7sr0ZMxtJr04ASXVzH5eBWtDkdb0c3LLFsehfPBTRfvlfKJOA==",
+      "hasInstallScript": true,
+      "dependencies": {
+        "playwright-core": "1.29.2"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "node_modules/playwright-core": {
       "version": "1.29.2",
       "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.29.2.tgz",
       "integrity": "sha512-94QXm4PMgFoHAhlCuoWyaBYKb92yOcGVHdQLoxQ7Wjlc7Flg4aC/jbFW7xMR52OfXMVkWicue4WXE7QEegbIRA==",
-      "dev": true,
       "bin": {
         "playwright": "cli.js"
       },
@@ -11523,11 +11538,18 @@
       "integrity": "sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==",
       "dev": true
     },
+    "playwright": {
+      "version": "1.29.2",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.29.2.tgz",
+      "integrity": "sha512-hKBYJUtdmYzcjdhYDkP9WGtORwwZBBKAW8+Lz7sr0ZMxtJr04ASXVzH5eBWtDkdb0c3LLFsehfPBTRfvlfKJOA==",
+      "requires": {
+        "playwright-core": "1.29.2"
+      }
+    },
     "playwright-core": {
       "version": "1.29.2",
       "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.29.2.tgz",
-      "integrity": "sha512-94QXm4PMgFoHAhlCuoWyaBYKb92yOcGVHdQLoxQ7Wjlc7Flg4aC/jbFW7xMR52OfXMVkWicue4WXE7QEegbIRA==",
-      "dev": true
+      "integrity": "sha512-94QXm4PMgFoHAhlCuoWyaBYKb92yOcGVHdQLoxQ7Wjlc7Flg4aC/jbFW7xMR52OfXMVkWicue4WXE7QEegbIRA=="
     },
     "postcss": {
       "version": "8.4.20",

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,12 +16,10 @@
         "@typescript-eslint/eslint-plugin": "^5.48.0",
         "@typescript-eslint/parser": "^5.48.0",
         "eslint": "^8.31.0",
-        "playwright": "^1.29.2",
         "prettier": "2.8.1",
         "release-it": "^15.6.0",
         "typescript": "^4.9.3",
-        "vite": "^4.0.0",
-        "vitest": "^0.26.3"
+        "vite": "^4.0.0"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -871,21 +869,6 @@
         "node": ">= 6"
       }
     },
-    "node_modules/@types/chai": {
-      "version": "4.3.4",
-      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.3.4.tgz",
-      "integrity": "sha512-KnRanxnpfpjUTqTCXslZSEdLfXExwgNxYPdiO2WGUj8+HDjFi8R3k5RVKPeSCzLjCcshCAtVO2QBbVuAV4kTnw==",
-      "dev": true
-    },
-    "node_modules/@types/chai-subset": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/@types/chai-subset/-/chai-subset-1.3.3.tgz",
-      "integrity": "sha512-frBecisrNGz+F4T6bcc+NLeolfiojh5FxW2klu669+8BARtyQv2C/GkNW6FUodVe4BroGMP/wER/YDGc7rEllw==",
-      "dev": true,
-      "dependencies": {
-        "@types/chai": "*"
-      }
-    },
     "node_modules/@types/json-schema": {
       "version": "7.0.11",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.11.tgz",
@@ -1296,15 +1279,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/assertion-error": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
-      "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
-      "dev": true,
-      "engines": {
-        "node": "*"
-      }
-    },
     "node_modules/ast-types": {
       "version": "0.13.4",
       "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.13.4.tgz",
@@ -1589,24 +1563,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/chai": {
-      "version": "4.3.7",
-      "resolved": "https://registry.npmjs.org/chai/-/chai-4.3.7.tgz",
-      "integrity": "sha512-HLnAzZ2iupm25PlN0xFreAlBA5zaBSv3og0DdeGA4Ar6h6rJ3A0rolRUKJhSF2V10GZKDgWF/VmAEsNWjCRB+A==",
-      "dev": true,
-      "dependencies": {
-        "assertion-error": "^1.1.0",
-        "check-error": "^1.0.2",
-        "deep-eql": "^4.1.2",
-        "get-func-name": "^2.0.0",
-        "loupe": "^2.3.1",
-        "pathval": "^1.1.1",
-        "type-detect": "^4.0.5"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -1628,15 +1584,6 @@
       "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
       "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
       "dev": true
-    },
-    "node_modules/check-error": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.2.tgz",
-      "integrity": "sha512-BrgHpW9NURQgzoNyjfq0Wu6VFO6D7IZEmJNdtgNqpzGG8RuNFHt2jQxWlAs4HMe119chBnv+34syEZtc6IhLtA==",
-      "dev": true,
-      "engines": {
-        "node": "*"
-      }
     },
     "node_modules/ci-info": {
       "version": "3.3.2",
@@ -2262,18 +2209,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/deep-eql": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-4.1.3.tgz",
-      "integrity": "sha512-WaEtAOpRA1MQ0eohqZjpGD8zdI0Ovsm8mmFhaDN8dvDZzyoUMcYDnf5Y6iu7HTXxf8JDS23qWa4a+hKCDyOPzw==",
-      "dev": true,
-      "dependencies": {
-        "type-detect": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=6"
       }
     },
     "node_modules/deep-extend": {
@@ -3240,15 +3175,6 @@
       "dev": true,
       "engines": {
         "node": "6.* || 8.* || >= 10.*"
-      }
-    },
-    "node_modules/get-func-name": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.0.tgz",
-      "integrity": "sha512-Hm0ixYtaSZ/V7C8FJrtZIuBBI+iSgL+1Aq82zSu8VQNB4S3Gk8e7Qs3VwBDJAhmRZcFqkl3tQu36g/Foh5I5ig==",
-      "dev": true,
-      "engines": {
-        "node": "*"
       }
     },
     "node_modules/get-intrinsic": {
@@ -4577,12 +4503,6 @@
       "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==",
       "dev": true
     },
-    "node_modules/jsonc-parser": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.2.0.tgz",
-      "integrity": "sha512-gfFQZrcTc8CnKXp6Y4/CBT3fTc0OVuDofpre4aEeEpSBPV5X5v4+Vmx+8snU7RLPrNHPKSgLxGo9YuQzz20o+w==",
-      "dev": true
-    },
     "node_modules/jsonfile": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
@@ -4706,18 +4626,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/local-pkg": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/local-pkg/-/local-pkg-0.4.2.tgz",
-      "integrity": "sha512-mlERgSPrbxU3BP4qBqAvvwlgW4MTg78iwJdGGnv7kibKjWcJksrG3t6LB5lXI93wXRDvG4NpUgJFmTG4T6rdrg==",
-      "dev": true,
-      "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/antfu"
-      }
-    },
     "node_modules/locate-path": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
@@ -4777,15 +4685,6 @@
       },
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
-    "node_modules/loupe": {
-      "version": "2.3.6",
-      "resolved": "https://registry.npmjs.org/loupe/-/loupe-2.3.6.tgz",
-      "integrity": "sha512-RaPMZKiMy8/JruncMU5Bt6na1eftNoo++R4Y+N2FrxkDVTrGvcyzFTsaGif4QTeKESheMGegbhw6iUAq+5A8zA==",
-      "dev": true,
-      "dependencies": {
-        "get-func-name": "^2.0.0"
       }
     },
     "node_modules/lowercase-keys": {
@@ -5124,24 +5023,6 @@
       "engines": {
         "node": ">= 6"
       }
-    },
-    "node_modules/mlly": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/mlly/-/mlly-1.0.0.tgz",
-      "integrity": "sha512-QL108Hwt+u9bXdWgOI0dhzZfACovn5Aen4Xvc8Jasd9ouRH4NjnrXEiyP3nVvJo91zPlYjVRckta0Nt2zfoR6g==",
-      "dev": true,
-      "dependencies": {
-        "acorn": "^8.8.1",
-        "pathe": "^1.0.0",
-        "pkg-types": "^1.0.0",
-        "ufo": "^1.0.0"
-      }
-    },
-    "node_modules/mlly/node_modules/pathe": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.0.0.tgz",
-      "integrity": "sha512-nPdMG0Pd09HuSsr7QOKUXO2Jr9eqaDiZvDwdyIhNG5SHYujkQHYKDfGQkulBxvbDHz8oHLsTgKN86LSwYzSHAg==",
-      "dev": true
     },
     "node_modules/modify-values": {
       "version": "1.0.1",
@@ -5692,21 +5573,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/pathe": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/pathe/-/pathe-0.2.0.tgz",
-      "integrity": "sha512-sTitTPYnn23esFR3RlqYBWn4c45WGeLcsKzQiUpXJAyfcWkolvlYpV8FLo7JishK946oQwMFUCHXQ9AjGPKExw==",
-      "dev": true
-    },
-    "node_modules/pathval": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.1.tgz",
-      "integrity": "sha512-Dp6zGqpTdETdR63lehJYPeIOqpiNBNtc7BpWSLrOje7UaIsE5aY92r/AunQA7rsXvet3lrJ3JnZX29UPTKXyKQ==",
-      "dev": true,
-      "engines": {
-        "node": "*"
-      }
-    },
     "node_modules/picocolors": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
@@ -5732,39 +5598,6 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/pkg-types": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-1.0.1.tgz",
-      "integrity": "sha512-jHv9HB+Ho7dj6ItwppRDDl0iZRYBD0jsakHXtFgoLr+cHSF6xC+QL54sJmWxyGxOLYSHm0afhXhXcQDQqH9z8g==",
-      "dev": true,
-      "dependencies": {
-        "jsonc-parser": "^3.2.0",
-        "mlly": "^1.0.0",
-        "pathe": "^1.0.0"
-      }
-    },
-    "node_modules/pkg-types/node_modules/pathe": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.0.0.tgz",
-      "integrity": "sha512-nPdMG0Pd09HuSsr7QOKUXO2Jr9eqaDiZvDwdyIhNG5SHYujkQHYKDfGQkulBxvbDHz8oHLsTgKN86LSwYzSHAg==",
-      "dev": true
-    },
-    "node_modules/playwright": {
-      "version": "1.29.2",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.29.2.tgz",
-      "integrity": "sha512-hKBYJUtdmYzcjdhYDkP9WGtORwwZBBKAW8+Lz7sr0ZMxtJr04ASXVzH5eBWtDkdb0c3LLFsehfPBTRfvlfKJOA==",
-      "dev": true,
-      "hasInstallScript": true,
-      "dependencies": {
-        "playwright-core": "1.29.2"
-      },
-      "bin": {
-        "playwright": "cli.js"
-      },
-      "engines": {
-        "node": ">=14"
       }
     },
     "node_modules/playwright-core": {
@@ -6734,16 +6567,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/source-map-support": {
-      "version": "0.5.21",
-      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
-      "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
-      "dev": true,
-      "dependencies": {
-        "buffer-from": "^1.0.0",
-        "source-map": "^0.6.0"
-      }
-    },
     "node_modules/spdx-correct": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.1.1.tgz",
@@ -6944,18 +6767,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/strip-literal": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/strip-literal/-/strip-literal-1.0.0.tgz",
-      "integrity": "sha512-5o4LsH1lzBzO9UFH63AJ2ad2/S2AVx6NtjOcaz+VTT2h1RiRvbipW72z8M/lxEhcPHDBQwpDrnTF7sXy/7OwCQ==",
-      "dev": true,
-      "dependencies": {
-        "acorn": "^8.8.1"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/antfu"
-      }
-    },
     "node_modules/supports-color": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -7008,30 +6819,6 @@
       "dev": true,
       "dependencies": {
         "readable-stream": "3"
-      }
-    },
-    "node_modules/tinybench": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.3.1.tgz",
-      "integrity": "sha512-hGYWYBMPr7p4g5IarQE7XhlyWveh1EKhy4wUBS1LrHXCKYgvz+4/jCqgmJqZxxldesn05vccrtME2RLLZNW7iA==",
-      "dev": true
-    },
-    "node_modules/tinypool": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-0.3.0.tgz",
-      "integrity": "sha512-NX5KeqHOBZU6Bc0xj9Vr5Szbb1j8tUHIeD18s41aDJaPeC5QTdEhK0SpdpUrZlj2nv5cctNcSjaKNanXlfcVEQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/tinyspy": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-1.0.2.tgz",
-      "integrity": "sha512-bSGlgwLBYf7PnUsQ6WOc6SJ3pGOcd+d8AA6EUnLDDM0kWEstC1JIlSZA3UNliDXhd9ABoS7hiRBDCu+XP/sf1Q==",
-      "dev": true,
-      "engines": {
-        "node": ">=14.0.0"
       }
     },
     "node_modules/tmp": {
@@ -7115,15 +6902,6 @@
         "node": ">= 0.8.0"
       }
     },
-    "node_modules/type-detect": {
-      "version": "4.0.8",
-      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
-      "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
-      "dev": true,
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/type-fest": {
       "version": "0.20.2",
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
@@ -7177,12 +6955,6 @@
       "engines": {
         "node": ">=4.2.0"
       }
-    },
-    "node_modules/ufo": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.0.1.tgz",
-      "integrity": "sha512-boAm74ubXHY7KJQZLlXrtMz52qFvpsbOxDcZOnw/Wf+LS4Mmyu7JxmzD4tDLtUQtmZECypJ0FrCz4QIe6dvKRA==",
-      "dev": true
     },
     "node_modules/uglify-js": {
       "version": "3.16.3",
@@ -7370,85 +7142,6 @@
           "optional": true
         },
         "terser": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/vite-node": {
-      "version": "0.26.3",
-      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-0.26.3.tgz",
-      "integrity": "sha512-Te2bq0Bfvq6XiO718I+1EinMjpNYKws6SNHKOmVbILAQimKoZKDd+IZLlkaYcBXPpK3HFe2U80k8Zw+m3w/a2w==",
-      "dev": true,
-      "dependencies": {
-        "debug": "^4.3.4",
-        "mlly": "^1.0.0",
-        "pathe": "^0.2.0",
-        "source-map": "^0.6.1",
-        "source-map-support": "^0.5.21",
-        "vite": "^3.0.0 || ^4.0.0"
-      },
-      "bin": {
-        "vite-node": "vite-node.mjs"
-      },
-      "engines": {
-        "node": ">=v14.16.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/antfu"
-      }
-    },
-    "node_modules/vitest": {
-      "version": "0.26.3",
-      "resolved": "https://registry.npmjs.org/vitest/-/vitest-0.26.3.tgz",
-      "integrity": "sha512-FmHxU9aUCxTi23keF3vxb/Qp0lYXaaJ+jRLGOUmMS3qVTOJvgGE+f1VArupA6pEhaG2Ans4X+zV9dqM5WISMbg==",
-      "dev": true,
-      "dependencies": {
-        "@types/chai": "^4.3.4",
-        "@types/chai-subset": "^1.3.3",
-        "@types/node": "*",
-        "acorn": "^8.8.1",
-        "acorn-walk": "^8.2.0",
-        "chai": "^4.3.7",
-        "debug": "^4.3.4",
-        "local-pkg": "^0.4.2",
-        "source-map": "^0.6.1",
-        "strip-literal": "^1.0.0",
-        "tinybench": "^2.3.1",
-        "tinypool": "^0.3.0",
-        "tinyspy": "^1.0.2",
-        "vite": "^3.0.0 || ^4.0.0",
-        "vite-node": "0.26.3"
-      },
-      "bin": {
-        "vitest": "vitest.mjs"
-      },
-      "engines": {
-        "node": ">=v14.16.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/antfu"
-      },
-      "peerDependencies": {
-        "@edge-runtime/vm": "*",
-        "@vitest/browser": "*",
-        "@vitest/ui": "*",
-        "happy-dom": "*",
-        "jsdom": "*"
-      },
-      "peerDependenciesMeta": {
-        "@edge-runtime/vm": {
-          "optional": true
-        },
-        "@vitest/browser": {
-          "optional": true
-        },
-        "@vitest/ui": {
-          "optional": true
-        },
-        "happy-dom": {
-          "optional": true
-        },
-        "jsdom": {
           "optional": true
         }
       }
@@ -8408,21 +8101,6 @@
       "integrity": "sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw==",
       "dev": true
     },
-    "@types/chai": {
-      "version": "4.3.4",
-      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.3.4.tgz",
-      "integrity": "sha512-KnRanxnpfpjUTqTCXslZSEdLfXExwgNxYPdiO2WGUj8+HDjFi8R3k5RVKPeSCzLjCcshCAtVO2QBbVuAV4kTnw==",
-      "dev": true
-    },
-    "@types/chai-subset": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/@types/chai-subset/-/chai-subset-1.3.3.tgz",
-      "integrity": "sha512-frBecisrNGz+F4T6bcc+NLeolfiojh5FxW2klu669+8BARtyQv2C/GkNW6FUodVe4BroGMP/wER/YDGc7rEllw==",
-      "dev": true,
-      "requires": {
-        "@types/chai": "*"
-      }
-    },
     "@types/json-schema": {
       "version": "7.0.11",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.11.tgz",
@@ -8694,12 +8372,6 @@
       "integrity": "sha512-3CYzex9M9FGQjCGMGyi6/31c8GJbgb0qGyrx5HWxPd0aCwh4cB2YjMb2Xf9UuoogrMrlO9cTqnB5rI5GHZTcUA==",
       "dev": true
     },
-    "assertion-error": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
-      "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
-      "dev": true
-    },
     "ast-types": {
       "version": "0.13.4",
       "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.13.4.tgz",
@@ -8899,21 +8571,6 @@
         }
       }
     },
-    "chai": {
-      "version": "4.3.7",
-      "resolved": "https://registry.npmjs.org/chai/-/chai-4.3.7.tgz",
-      "integrity": "sha512-HLnAzZ2iupm25PlN0xFreAlBA5zaBSv3og0DdeGA4Ar6h6rJ3A0rolRUKJhSF2V10GZKDgWF/VmAEsNWjCRB+A==",
-      "dev": true,
-      "requires": {
-        "assertion-error": "^1.1.0",
-        "check-error": "^1.0.2",
-        "deep-eql": "^4.1.2",
-        "get-func-name": "^2.0.0",
-        "loupe": "^2.3.1",
-        "pathval": "^1.1.1",
-        "type-detect": "^4.0.5"
-      }
-    },
     "chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -8928,12 +8585,6 @@
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
       "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
-      "dev": true
-    },
-    "check-error": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.2.tgz",
-      "integrity": "sha512-BrgHpW9NURQgzoNyjfq0Wu6VFO6D7IZEmJNdtgNqpzGG8RuNFHt2jQxWlAs4HMe119chBnv+34syEZtc6IhLtA==",
       "dev": true
     },
     "ci-info": {
@@ -9410,15 +9061,6 @@
           "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
           "dev": true
         }
-      }
-    },
-    "deep-eql": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-4.1.3.tgz",
-      "integrity": "sha512-WaEtAOpRA1MQ0eohqZjpGD8zdI0Ovsm8mmFhaDN8dvDZzyoUMcYDnf5Y6iu7HTXxf8JDS23qWa4a+hKCDyOPzw==",
-      "dev": true,
-      "requires": {
-        "type-detect": "^4.0.0"
       }
     },
     "deep-extend": {
@@ -10151,12 +9793,6 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
       "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
-      "dev": true
-    },
-    "get-func-name": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.0.tgz",
-      "integrity": "sha512-Hm0ixYtaSZ/V7C8FJrtZIuBBI+iSgL+1Aq82zSu8VQNB4S3Gk8e7Qs3VwBDJAhmRZcFqkl3tQu36g/Foh5I5ig==",
       "dev": true
     },
     "get-intrinsic": {
@@ -11109,12 +10745,6 @@
       "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==",
       "dev": true
     },
-    "jsonc-parser": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.2.0.tgz",
-      "integrity": "sha512-gfFQZrcTc8CnKXp6Y4/CBT3fTc0OVuDofpre4aEeEpSBPV5X5v4+Vmx+8snU7RLPrNHPKSgLxGo9YuQzz20o+w==",
-      "dev": true
-    },
     "jsonfile": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
@@ -11210,12 +10840,6 @@
         }
       }
     },
-    "local-pkg": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/local-pkg/-/local-pkg-0.4.2.tgz",
-      "integrity": "sha512-mlERgSPrbxU3BP4qBqAvvwlgW4MTg78iwJdGGnv7kibKjWcJksrG3t6LB5lXI93wXRDvG4NpUgJFmTG4T6rdrg==",
-      "dev": true
-    },
     "locate-path": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
@@ -11259,15 +10883,6 @@
           "integrity": "sha512-ree3Gqw/nazQAPuJJEy+avdl7QfZMcUvmHIKgEZkGL+xOBzRvup5Hxo6LHuMceSxOabuJLJm5Yp/92R9eMmMvA==",
           "dev": true
         }
-      }
-    },
-    "loupe": {
-      "version": "2.3.6",
-      "resolved": "https://registry.npmjs.org/loupe/-/loupe-2.3.6.tgz",
-      "integrity": "sha512-RaPMZKiMy8/JruncMU5Bt6na1eftNoo++R4Y+N2FrxkDVTrGvcyzFTsaGif4QTeKESheMGegbhw6iUAq+5A8zA==",
-      "dev": true,
-      "requires": {
-        "get-func-name": "^2.0.0"
       }
     },
     "lowercase-keys": {
@@ -11509,26 +11124,6 @@
         "arrify": "^1.0.1",
         "is-plain-obj": "^1.1.0",
         "kind-of": "^6.0.3"
-      }
-    },
-    "mlly": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/mlly/-/mlly-1.0.0.tgz",
-      "integrity": "sha512-QL108Hwt+u9bXdWgOI0dhzZfACovn5Aen4Xvc8Jasd9ouRH4NjnrXEiyP3nVvJo91zPlYjVRckta0Nt2zfoR6g==",
-      "dev": true,
-      "requires": {
-        "acorn": "^8.8.1",
-        "pathe": "^1.0.0",
-        "pkg-types": "^1.0.0",
-        "ufo": "^1.0.0"
-      },
-      "dependencies": {
-        "pathe": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.0.0.tgz",
-          "integrity": "sha512-nPdMG0Pd09HuSsr7QOKUXO2Jr9eqaDiZvDwdyIhNG5SHYujkQHYKDfGQkulBxvbDHz8oHLsTgKN86LSwYzSHAg==",
-          "dev": true
-        }
       }
     },
     "modify-values": {
@@ -11910,18 +11505,6 @@
       "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
       "dev": true
     },
-    "pathe": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/pathe/-/pathe-0.2.0.tgz",
-      "integrity": "sha512-sTitTPYnn23esFR3RlqYBWn4c45WGeLcsKzQiUpXJAyfcWkolvlYpV8FLo7JishK946oQwMFUCHXQ9AjGPKExw==",
-      "dev": true
-    },
-    "pathval": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.1.tgz",
-      "integrity": "sha512-Dp6zGqpTdETdR63lehJYPeIOqpiNBNtc7BpWSLrOje7UaIsE5aY92r/AunQA7rsXvet3lrJ3JnZX29UPTKXyKQ==",
-      "dev": true
-    },
     "picocolors": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
@@ -11939,34 +11522,6 @@
       "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
       "integrity": "sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==",
       "dev": true
-    },
-    "pkg-types": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-1.0.1.tgz",
-      "integrity": "sha512-jHv9HB+Ho7dj6ItwppRDDl0iZRYBD0jsakHXtFgoLr+cHSF6xC+QL54sJmWxyGxOLYSHm0afhXhXcQDQqH9z8g==",
-      "dev": true,
-      "requires": {
-        "jsonc-parser": "^3.2.0",
-        "mlly": "^1.0.0",
-        "pathe": "^1.0.0"
-      },
-      "dependencies": {
-        "pathe": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.0.0.tgz",
-          "integrity": "sha512-nPdMG0Pd09HuSsr7QOKUXO2Jr9eqaDiZvDwdyIhNG5SHYujkQHYKDfGQkulBxvbDHz8oHLsTgKN86LSwYzSHAg==",
-          "dev": true
-        }
-      }
-    },
-    "playwright": {
-      "version": "1.29.2",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.29.2.tgz",
-      "integrity": "sha512-hKBYJUtdmYzcjdhYDkP9WGtORwwZBBKAW8+Lz7sr0ZMxtJr04ASXVzH5eBWtDkdb0c3LLFsehfPBTRfvlfKJOA==",
-      "dev": true,
-      "requires": {
-        "playwright-core": "1.29.2"
-      }
     },
     "playwright-core": {
       "version": "1.29.2",
@@ -12648,16 +12203,6 @@
       "integrity": "sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==",
       "dev": true
     },
-    "source-map-support": {
-      "version": "0.5.21",
-      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
-      "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
-      "dev": true,
-      "requires": {
-        "buffer-from": "^1.0.0",
-        "source-map": "^0.6.0"
-      }
-    },
     "spdx-correct": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.1.1.tgz",
@@ -12809,15 +12354,6 @@
       "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
       "dev": true
     },
-    "strip-literal": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/strip-literal/-/strip-literal-1.0.0.tgz",
-      "integrity": "sha512-5o4LsH1lzBzO9UFH63AJ2ad2/S2AVx6NtjOcaz+VTT2h1RiRvbipW72z8M/lxEhcPHDBQwpDrnTF7sXy/7OwCQ==",
-      "dev": true,
-      "requires": {
-        "acorn": "^8.8.1"
-      }
-    },
     "supports-color": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -12859,24 +12395,6 @@
       "requires": {
         "readable-stream": "3"
       }
-    },
-    "tinybench": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.3.1.tgz",
-      "integrity": "sha512-hGYWYBMPr7p4g5IarQE7XhlyWveh1EKhy4wUBS1LrHXCKYgvz+4/jCqgmJqZxxldesn05vccrtME2RLLZNW7iA==",
-      "dev": true
-    },
-    "tinypool": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-0.3.0.tgz",
-      "integrity": "sha512-NX5KeqHOBZU6Bc0xj9Vr5Szbb1j8tUHIeD18s41aDJaPeC5QTdEhK0SpdpUrZlj2nv5cctNcSjaKNanXlfcVEQ==",
-      "dev": true
-    },
-    "tinyspy": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-1.0.2.tgz",
-      "integrity": "sha512-bSGlgwLBYf7PnUsQ6WOc6SJ3pGOcd+d8AA6EUnLDDM0kWEstC1JIlSZA3UNliDXhd9ABoS7hiRBDCu+XP/sf1Q==",
-      "dev": true
     },
     "tmp": {
       "version": "0.0.33",
@@ -12938,12 +12456,6 @@
         "prelude-ls": "^1.2.1"
       }
     },
-    "type-detect": {
-      "version": "4.0.8",
-      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
-      "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
-      "dev": true
-    },
     "type-fest": {
       "version": "0.20.2",
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
@@ -12980,12 +12492,6 @@
       "version": "4.9.4",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.4.tgz",
       "integrity": "sha512-Uz+dTXYzxXXbsFpM86Wh3dKCxrQqUcVMxwU54orwlJjOpO3ao8L7j5lH+dWfTwgCwIuM9GQ2kvVotzYJMXTBZg==",
-      "dev": true
-    },
-    "ufo": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.0.1.tgz",
-      "integrity": "sha512-boAm74ubXHY7KJQZLlXrtMz52qFvpsbOxDcZOnw/Wf+LS4Mmyu7JxmzD4tDLtUQtmZECypJ0FrCz4QIe6dvKRA==",
       "dev": true
     },
     "uglify-js": {
@@ -13106,43 +12612,6 @@
         "postcss": "^8.4.20",
         "resolve": "^1.22.1",
         "rollup": "^3.7.0"
-      }
-    },
-    "vite-node": {
-      "version": "0.26.3",
-      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-0.26.3.tgz",
-      "integrity": "sha512-Te2bq0Bfvq6XiO718I+1EinMjpNYKws6SNHKOmVbILAQimKoZKDd+IZLlkaYcBXPpK3HFe2U80k8Zw+m3w/a2w==",
-      "dev": true,
-      "requires": {
-        "debug": "^4.3.4",
-        "mlly": "^1.0.0",
-        "pathe": "^0.2.0",
-        "source-map": "^0.6.1",
-        "source-map-support": "^0.5.21",
-        "vite": "^3.0.0 || ^4.0.0"
-      }
-    },
-    "vitest": {
-      "version": "0.26.3",
-      "resolved": "https://registry.npmjs.org/vitest/-/vitest-0.26.3.tgz",
-      "integrity": "sha512-FmHxU9aUCxTi23keF3vxb/Qp0lYXaaJ+jRLGOUmMS3qVTOJvgGE+f1VArupA6pEhaG2Ans4X+zV9dqM5WISMbg==",
-      "dev": true,
-      "requires": {
-        "@types/chai": "^4.3.4",
-        "@types/chai-subset": "^1.3.3",
-        "@types/node": "*",
-        "acorn": "^8.8.1",
-        "acorn-walk": "^8.2.0",
-        "chai": "^4.3.7",
-        "debug": "^4.3.4",
-        "local-pkg": "^0.4.2",
-        "source-map": "^0.6.1",
-        "strip-literal": "^1.0.0",
-        "tinybench": "^2.3.1",
-        "tinypool": "^0.3.0",
-        "tinyspy": "^1.0.2",
-        "vite": "^3.0.0 || ^4.0.0",
-        "vite-node": "0.26.3"
       }
     },
     "vm2": {

--- a/package.json
+++ b/package.json
@@ -16,7 +16,9 @@
     "build": "tsc && vite build",
     "preview": "vite preview",
     "format": "prettier --write .",
-    "release": "release-it --only-version"
+    "release": "release-it --only-version",
+    "test": "vitest",
+    "coverage": "vite && vitest run --coverage"
   },
   "type": "module",
   "module": "./dist/datetime-web-component.es.js",
@@ -30,13 +32,16 @@
     "@floating-ui/dom": "^1.0.0"
   },
   "devDependencies": {
+    "@playwright/test": "^1.29.2",
     "@release-it/conventional-changelog": "^5.0.0",
     "@typescript-eslint/eslint-plugin": "^5.48.0",
     "@typescript-eslint/parser": "^5.48.0",
     "eslint": "^8.31.0",
+    "playwright": "^1.29.2",
     "prettier": "2.8.1",
     "release-it": "^15.6.0",
     "typescript": "^4.9.3",
-    "vite": "^4.0.0"
+    "vite": "^4.0.0",
+    "vitest": "^0.26.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -17,8 +17,7 @@
     "preview": "vite preview",
     "format": "prettier --write .",
     "release": "release-it --only-version",
-    "test": "vitest",
-    "coverage": "vite && vitest run --coverage"
+    "test": "playwright test"
   },
   "type": "module",
   "module": "./dist/datetime-web-component.es.js",
@@ -37,11 +36,9 @@
     "@typescript-eslint/eslint-plugin": "^5.48.0",
     "@typescript-eslint/parser": "^5.48.0",
     "eslint": "^8.31.0",
-    "playwright": "^1.29.2",
     "prettier": "2.8.1",
     "release-it": "^15.6.0",
     "typescript": "^4.9.3",
-    "vite": "^4.0.0",
-    "vitest": "^0.26.3"
+    "vite": "^4.0.0"
   }
 }

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,107 @@
+import type { PlaywrightTestConfig } from '@playwright/test';
+import { devices } from '@playwright/test';
+
+/**
+ * Read environment variables from file.
+ * https://github.com/motdotla/dotenv
+ */
+// require('dotenv').config();
+
+/**
+ * See https://playwright.dev/docs/test-configuration.
+ */
+const config: PlaywrightTestConfig = {
+  testDir: './tests',
+  /* Maximum time one test can run for. */
+  timeout: 30 * 1000,
+  expect: {
+    /**
+     * Maximum time expect() should wait for the condition to be met.
+     * For example in `await expect(locator).toHaveText();`
+     */
+    timeout: 5000
+  },
+  /* Run tests in files in parallel */
+  fullyParallel: true,
+  /* Fail the build on CI if you accidentally left test.only in the source code. */
+  forbidOnly: !!process.env.CI,
+  /* Retry on CI only */
+  retries: process.env.CI ? 2 : 0,
+  /* Opt out of parallel tests on CI. */
+  workers: process.env.CI ? 1 : undefined,
+  /* Reporter to use. See https://playwright.dev/docs/test-reporters */
+  reporter: 'html',
+  /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
+  use: {
+    /* Maximum time each action such as `click()` can take. Defaults to 0 (no limit). */
+    actionTimeout: 0,
+    /* Base URL to use in actions like `await page.goto('/')`. */
+    // baseURL: 'http://localhost:3000',
+
+    /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
+    trace: 'on-first-retry',
+  },
+
+  /* Configure projects for major browsers */
+  projects: [
+    {
+      name: 'chromium',
+      use: {
+        ...devices['Desktop Chrome'],
+      },
+    },
+
+    {
+      name: 'firefox',
+      use: {
+        ...devices['Desktop Firefox'],
+      },
+    },
+
+    {
+      name: 'webkit',
+      use: {
+        ...devices['Desktop Safari'],
+      },
+    },
+
+    /* Test against mobile viewports. */
+    // {
+    //   name: 'Mobile Chrome',
+    //   use: {
+    //     ...devices['Pixel 5'],
+    //   },
+    // },
+    // {
+    //   name: 'Mobile Safari',
+    //   use: {
+    //     ...devices['iPhone 12'],
+    //   },
+    // },
+
+    /* Test against branded browsers. */
+    // {
+    //   name: 'Microsoft Edge',
+    //   use: {
+    //     channel: 'msedge',
+    //   },
+    // },
+    // {
+    //   name: 'Google Chrome',
+    //   use: {
+    //     channel: 'chrome',
+    //   },
+    // },
+  ],
+
+  /* Folder for test artifacts such as screenshots, videos, traces, etc. */
+  // outputDir: 'test-results/',
+
+  /* Run your local dev server before starting the tests */
+  // webServer: {
+  //   command: 'npm run start',
+  //   port: 3000,
+  // },
+};
+
+export default config;

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,5 +1,5 @@
-import type { PlaywrightTestConfig } from '@playwright/test';
-import { devices } from '@playwright/test';
+import type { PlaywrightTestConfig } from '@playwright/test'
+import { devices } from '@playwright/test'
 
 /**
  * Read environment variables from file.
@@ -19,7 +19,7 @@ const config: PlaywrightTestConfig = {
      * Maximum time expect() should wait for the condition to be met.
      * For example in `await expect(locator).toHaveText();`
      */
-    timeout: 5000
+    timeout: 5000,
   },
   /* Run tests in files in parallel */
   fullyParallel: true,
@@ -43,7 +43,7 @@ const config: PlaywrightTestConfig = {
 
     locale: 'nl-BE',
 
-    timezoneId: 'Europe/Brussels'
+    timezoneId: 'Europe/Brussels',
   },
 
   /* Configure projects for major browsers */
@@ -106,6 +106,6 @@ const config: PlaywrightTestConfig = {
     command: 'npm run dev',
     port: 5173,
   },
-};
+}
 
-export default config;
+export default config

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -40,6 +40,10 @@ const config: PlaywrightTestConfig = {
 
     /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
     trace: 'on-first-retry',
+
+    locale: 'nl-BE',
+
+    timezoneId: 'Europe/Brussels'
   },
 
   /* Configure projects for major browsers */

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -36,7 +36,7 @@ const config: PlaywrightTestConfig = {
     /* Maximum time each action such as `click()` can take. Defaults to 0 (no limit). */
     actionTimeout: 0,
     /* Base URL to use in actions like `await page.goto('/')`. */
-    // baseURL: 'http://localhost:3000',
+    baseURL: 'http://localhost:5173',
 
     /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
     trace: 'on-first-retry',
@@ -98,10 +98,10 @@ const config: PlaywrightTestConfig = {
   // outputDir: 'test-results/',
 
   /* Run your local dev server before starting the tests */
-  // webServer: {
-  //   command: 'npm run start',
-  //   port: 3000,
-  // },
+  webServer: {
+    command: 'npm run dev',
+    port: 5173,
+  },
 };
 
 export default config;

--- a/src/components/DatetimeWebComponent.ts
+++ b/src/components/DatetimeWebComponent.ts
@@ -19,6 +19,8 @@ import getFirstDayOfMonth from './utils/getFirstDayOfMonth'
 import parseUTCDate from './utils/parseUTCDate'
 import setTimeInputs from './utils/setTimeInputs'
 
+type isDayBlockedFn = (value?: Date) => boolean
+
 class DatetimeWebComponent extends HTMLElement {
   // Date representation of the value
   _date?: Date
@@ -33,7 +35,7 @@ class DatetimeWebComponent extends HTMLElement {
   _refElement?: HTMLElement
 
   // Function to block specific days
-  _isDayBlocked = (_value: Date) => false
+  _isDayBlocked: isDayBlockedFn = () => false
 
   // LIFECYCLE METHODS
 

--- a/src/components/DatetimeWebComponent.ts
+++ b/src/components/DatetimeWebComponent.ts
@@ -147,8 +147,8 @@ class DatetimeWebComponent extends HTMLElement {
           this._monthIndex === this._tempMonthIndex
         const isBlocked = this._isDayBlocked(
           new Date(
-            this._tempYear || this._year,
-            this._tempMonthIndex || this._monthIndex,
+            this._tempYear ?? this._year,
+            this._tempMonthIndex ?? this._monthIndex,
             number
           )
         )

--- a/src/components/DatetimeWebComponent.ts
+++ b/src/components/DatetimeWebComponent.ts
@@ -101,6 +101,7 @@ class DatetimeWebComponent extends HTMLElement {
 
   set onlyDate(value: boolean) {
     this._setBooleanAttribute('only-date', value)
+    this._render()
   }
 
   get onlyDate() {
@@ -109,6 +110,7 @@ class DatetimeWebComponent extends HTMLElement {
 
   set showSeconds(value: boolean) {
     this._setBooleanAttribute('show-seconds', value)
+    this._render()
   }
 
   get showSeconds() {

--- a/src/components/utils/createCell.ts
+++ b/src/components/utils/createCell.ts
@@ -22,18 +22,19 @@ function createCell(
 
   if (isBlocked) {
     cell.classList.add('cell--blocked')
-    cell.setAttribute('data-testid', 'blocked-cell')
+    cell.dataset.testid = 'blocked-cell'
   } else if (isSelected) {
     cell.classList.add('cell--selected')
-    cell.setAttribute('data-testid', 'selected-cell');
+    cell.dataset.testid = 'selected-cell'
   } else if (isHeader) {
     cell.classList.add('cell--header')
-    cell.setAttribute('data-testid', 'header-cell')
+    cell.dataset.testid = 'header-cell'
   } else if (isInactive) {
     cell.classList.add('cell--inactive')
-    cell.setAttribute('data-testid', 'inactive-cell')
+    cell.dataset.testid = 'inactive-cell'
   } else {
     cell.classList.add('cell--default')
+    cell.dataset.testid = 'default-cell'
     cell.addEventListener('click', () => {
       cell.dispatchEvent(new CellEvent({ day: parseInt(label, 10) }))
     })

--- a/src/components/utils/createCell.ts
+++ b/src/components/utils/createCell.ts
@@ -16,6 +16,7 @@ function createCell(
 
   if (isSelected) {
     cell.classList.add('cell--selected')
+    cell.setAttribute('data-testid', 'day');
   } else if (isHeader) {
     cell.classList.add('cell--header')
   } else if (isInactive) {

--- a/src/components/utils/createCell.ts
+++ b/src/components/utils/createCell.ts
@@ -22,14 +22,16 @@ function createCell(
 
   if (isBlocked) {
     cell.classList.add('cell--blocked')
+    cell.setAttribute('data-testid', 'blocked-cell')
   } else if (isSelected) {
     cell.classList.add('cell--selected')
-    cell.setAttribute('data-testid', 'day');
+    cell.setAttribute('data-testid', 'selected-cell');
   } else if (isHeader) {
     cell.classList.add('cell--header')
     cell.setAttribute('data-testid', 'header-cell')
   } else if (isInactive) {
     cell.classList.add('cell--inactive')
+    cell.setAttribute('data-testid', 'inactive-cell')
   } else {
     cell.classList.add('cell--default')
     cell.addEventListener('click', () => {

--- a/src/components/utils/createCell.ts
+++ b/src/components/utils/createCell.ts
@@ -27,6 +27,7 @@ function createCell(
     cell.setAttribute('data-testid', 'day');
   } else if (isHeader) {
     cell.classList.add('cell--header')
+    cell.setAttribute('data-testid', 'header-cell')
   } else if (isInactive) {
     cell.classList.add('cell--inactive')
   } else {

--- a/src/components/utils/createHeader.ts
+++ b/src/components/utils/createHeader.ts
@@ -2,12 +2,22 @@ import Months from '../constants/Months'
 import MonthYearEvent from '../events/MonthYearEvent'
 import createSemanticButton from './createSemanticButton'
 
-function createArrowButton(
-  label: string,
-  newYear: number,
+type CreateArrowButtonOptions = {
+  label: string
+  newYear: number
   newMonthIndex: number
+  dataTestid: string
+}
+
+function createArrowButton({
+  label,
+  newYear,
+  newMonthIndex,
+  dataTestid
+}: CreateArrowButtonOptions
 ) {
   const button = createSemanticButton({ label, isIcon: true })
+  button.setAttribute('data-testid', dataTestid)
   button.addEventListener('click', () => {
     button.dispatchEvent(
       new MonthYearEvent({ year: newYear, monthIndex: newMonthIndex })
@@ -38,16 +48,18 @@ function createHeader(year: number, monthIndex: number) {
   container.className = 'header'
   const isFirstMonth = monthIndex === 0
   const isLastMonth = monthIndex === 11
-  const leftButton = createArrowButton(
-    '←',
-    isFirstMonth ? year - 1 : year,
-    isFirstMonth ? 11 : monthIndex - 1
-  )
-  const rightButton = createArrowButton(
-    '→',
-    isLastMonth ? year + 1 : year,
-    isLastMonth ? 0 : monthIndex + 1
-  )
+  const leftButton = createArrowButton({
+    label: '←',
+    newYear: isFirstMonth ? year - 1 : year,
+    newMonthIndex: isFirstMonth ? 11 : monthIndex - 1,
+    dataTestid: 'previous-month'
+})
+  const rightButton = createArrowButton({
+    label: '→',
+    newYear: isLastMonth ? year + 1 : year,
+    newMonthIndex: isLastMonth ? 0 : monthIndex + 1,
+    dataTestid: 'next-month'
+  })
   container.appendChild(leftButton)
   container.appendChild(createMonthYearSelector(year, Months[monthIndex]))
   container.appendChild(rightButton)

--- a/src/components/utils/createHeader.ts
+++ b/src/components/utils/createHeader.ts
@@ -7,7 +7,7 @@ function createArrowButton(
   newYear: number,
   newMonthIndex: number
 ) {
-  const button = createSemanticButton(label, true)
+  const button = createSemanticButton({ label, isIcon: true })
   button.addEventListener('click', () => {
     button.dispatchEvent(
       new MonthYearEvent({ year: newYear, monthIndex: newMonthIndex })
@@ -19,11 +19,11 @@ function createArrowButton(
 
 function createMonthYearSelector(year: number, month: string) {
   const div = document.createElement('div')
-  const monthButton = createSemanticButton(month)
+  const monthButton = createSemanticButton({ label: month, dataTestid: 'month' })
   monthButton.addEventListener('click', () => {
     monthButton.dispatchEvent(new Event('month-click', { bubbles: true }))
   })
-  const yearButton = createSemanticButton(year.toString())
+  const yearButton = createSemanticButton({ label: year.toString(), dataTestid: 'year' })
   yearButton.addEventListener('click', () => {
     yearButton.dispatchEvent(new Event('year-click', { bubbles: true }))
   })

--- a/src/components/utils/createHeader.ts
+++ b/src/components/utils/createHeader.ts
@@ -13,11 +13,9 @@ function createArrowButton({
   label,
   newYear,
   newMonthIndex,
-  dataTestid
-}: CreateArrowButtonOptions
-) {
-  const button = createSemanticButton({ label, isIcon: true })
-  button.setAttribute('data-testid', dataTestid)
+  dataTestid,
+}: CreateArrowButtonOptions) {
+  const button = createSemanticButton({ label, isIcon: true, dataTestid })
   button.addEventListener('click', () => {
     button.dispatchEvent(
       new MonthYearEvent({ year: newYear, monthIndex: newMonthIndex })
@@ -29,11 +27,17 @@ function createArrowButton({
 
 function createMonthYearSelector(year: number, month: string) {
   const div = document.createElement('div')
-  const monthButton = createSemanticButton({ label: month, dataTestid: 'month' })
+  const monthButton = createSemanticButton({
+    label: month,
+    dataTestid: 'month',
+  })
   monthButton.addEventListener('click', () => {
     monthButton.dispatchEvent(new Event('month-click', { bubbles: true }))
   })
-  const yearButton = createSemanticButton({ label: year.toString(), dataTestid: 'year' })
+  const yearButton = createSemanticButton({
+    label: year.toString(),
+    dataTestid: 'year',
+  })
   yearButton.addEventListener('click', () => {
     yearButton.dispatchEvent(new Event('year-click', { bubbles: true }))
   })
@@ -52,13 +56,13 @@ function createHeader(year: number, monthIndex: number) {
     label: '←',
     newYear: isFirstMonth ? year - 1 : year,
     newMonthIndex: isFirstMonth ? 11 : monthIndex - 1,
-    dataTestid: 'previous-month'
-})
+    dataTestid: 'previous-month',
+  })
   const rightButton = createArrowButton({
     label: '→',
     newYear: isLastMonth ? year + 1 : year,
     newMonthIndex: isLastMonth ? 0 : monthIndex + 1,
-    dataTestid: 'next-month'
+    dataTestid: 'next-month',
   })
   container.appendChild(leftButton)
   container.appendChild(createMonthYearSelector(year, Months[monthIndex]))

--- a/src/components/utils/createMonthCells.ts
+++ b/src/components/utils/createMonthCells.ts
@@ -13,6 +13,7 @@ function createMonthCells({ label, monthIndex, isSelected }: MonthCellOptions) {
     cell.classList.add('cell--selected')
   }
   cell.classList.add('cell--month')
+  cell.classList.add('cell--default')
   cell.textContent = label
   cell.addEventListener('click', () => {
     cell.dispatchEvent(new CellEvent({ month: monthIndex }))

--- a/src/components/utils/createMonthCells.ts
+++ b/src/components/utils/createMonthCells.ts
@@ -8,6 +8,7 @@ type MonthCellOptions = {
 
 function createMonthCells({ label, monthIndex, isSelected }: MonthCellOptions) {
   const cell = document.createElement('div')
+  cell.dataset.testid = 'month-cell'
   cell.classList.add('cell')
   if (isSelected) {
     cell.classList.add('cell--selected')

--- a/src/components/utils/createSemanticButton.ts
+++ b/src/components/utils/createSemanticButton.ts
@@ -4,14 +4,18 @@ type SemanticButtonOptions = {
   dataTestid?: string
 }
 
-function createSemanticButton({ label, isIcon = false, dataTestid = '' }: SemanticButtonOptions) {
+function createSemanticButton({
+  label,
+  isIcon = false,
+  dataTestid = '',
+}: SemanticButtonOptions) {
   const button = document.createElement('button')
+  button.dataset.testid = dataTestid
   button.className = 'semantic-button'
   if (isIcon) {
     button.classList.add('semantic-button--icon')
   }
   button.textContent = label
-  button.setAttribute('data-testid', dataTestid);
 
   return button
 }

--- a/src/components/utils/createSemanticButton.ts
+++ b/src/components/utils/createSemanticButton.ts
@@ -1,10 +1,17 @@
-function createSemanticButton(label: string, isIcon = false) {
+type SemanticButtonOptions = {
+  label: string
+  isIcon?: boolean
+  dataTestid?: string
+}
+
+function createSemanticButton({ label, isIcon = false, dataTestid = '' }: SemanticButtonOptions) {
   const button = document.createElement('button')
   button.className = 'semantic-button'
   if (isIcon) {
     button.classList.add('semantic-button--icon')
   }
   button.textContent = label
+  button.setAttribute('data-testid', dataTestid);
 
   return button
 }

--- a/src/components/utils/createTimeInput.ts
+++ b/src/components/utils/createTimeInput.ts
@@ -31,6 +31,7 @@ function parseValueFromEvent(event: Event) {
 function createHoursInput(date: Date) {
   const input = createNumberInput(formatTime(date.getHours()), 24)
   input.id = 'hours'
+  input.setAttribute('data-testid', 'hours')
   input.addEventListener('input', (event) => {
     input.dispatchEvent(
       new TimeEvent({
@@ -48,6 +49,7 @@ function createHoursInput(date: Date) {
 function createMinutesInput(date: Date) {
   const input = createNumberInput(formatTime(date.getMinutes()), 60)
   input.id = 'minutes'
+  input.setAttribute('data-testid', 'minutes')
   input.addEventListener('input', (event) => {
     input.dispatchEvent(
       new TimeEvent({
@@ -64,6 +66,7 @@ function createMinutesInput(date: Date) {
 function createSecondsInput(date: Date) {
   const input = createNumberInput(formatTime(date.getSeconds()), 60)
   input.id = 'seconds'
+  input.setAttribute('data-testid', 'seconds')
   input.addEventListener('input', (event) => {
     input.dispatchEvent(
       new TimeEvent({

--- a/src/components/utils/createTimeInput.ts
+++ b/src/components/utils/createTimeInput.ts
@@ -31,7 +31,7 @@ function parseValueFromEvent(event: Event) {
 function createHoursInput(date: Date) {
   const input = createNumberInput(formatTime(date.getHours()), 24)
   input.id = 'hours'
-  input.setAttribute('data-testid', 'hours')
+  input.dataset.testid = 'hours'
   input.addEventListener('input', (event) => {
     input.dispatchEvent(
       new TimeEvent({
@@ -49,7 +49,7 @@ function createHoursInput(date: Date) {
 function createMinutesInput(date: Date) {
   const input = createNumberInput(formatTime(date.getMinutes()), 60)
   input.id = 'minutes'
-  input.setAttribute('data-testid', 'minutes')
+  input.dataset.testid = 'minutes'
   input.addEventListener('input', (event) => {
     input.dispatchEvent(
       new TimeEvent({
@@ -66,7 +66,7 @@ function createMinutesInput(date: Date) {
 function createSecondsInput(date: Date) {
   const input = createNumberInput(formatTime(date.getSeconds()), 60)
   input.id = 'seconds'
-  input.setAttribute('data-testid', 'seconds')
+  input.dataset.testid = 'seconds'
   input.addEventListener('input', (event) => {
     input.dispatchEvent(
       new TimeEvent({
@@ -86,7 +86,7 @@ function createTimeInput(
   { showSeconds = false }: TimeInputOptions
 ) {
   const container = document.createElement('div')
-  container.setAttribute('data-testid', 'time-container')
+  container.dataset.testid = 'time-container'
   container.className = 'container container--time'
   container.appendChild(createHoursInput(date))
   container.appendChild(createSeparator())

--- a/src/components/utils/createTimeInput.ts
+++ b/src/components/utils/createTimeInput.ts
@@ -86,6 +86,7 @@ function createTimeInput(
   { showSeconds = false }: TimeInputOptions
 ) {
   const container = document.createElement('div')
+  container.setAttribute('data-testid', 'time-container')
   container.className = 'container container--time'
   container.appendChild(createHoursInput(date))
   container.appendChild(createSeparator())

--- a/src/components/utils/createYearView.ts
+++ b/src/components/utils/createYearView.ts
@@ -16,7 +16,7 @@ function createYearView(year: number) {
   container.className = 'container container--year'
   const yearInput = createYearInput(year)
   yearInput.addEventListener('input', (event) => event.stopPropagation())
-  const okButton = createSemanticButton('✓', true)
+  const okButton = createSemanticButton({ label: '✓', isIcon: true })
   okButton.addEventListener('click', () => {
     const newYear = yearInput.value
     yearInput.dispatchEvent(new MonthYearEvent({ year: parseInt(newYear, 10) }))

--- a/src/components/utils/createYearView.ts
+++ b/src/components/utils/createYearView.ts
@@ -3,6 +3,7 @@ import createSemanticButton from './createSemanticButton'
 
 function createYearInput(year: number) {
   const input = document.createElement('input')
+  input.dataset.testid = 'year-input'
   input.type = 'number'
   input.className = 'input input--year'
   input.min = '0'
@@ -16,7 +17,11 @@ function createYearView(year: number) {
   container.className = 'container container--year'
   const yearInput = createYearInput(year)
   yearInput.addEventListener('input', (event) => event.stopPropagation())
-  const okButton = createSemanticButton({ label: '✓', isIcon: true })
+  const okButton = createSemanticButton({
+    label: '✓',
+    isIcon: true,
+    dataTestid: 'confirm-year',
+  })
   okButton.addEventListener('click', () => {
     const newYear = yearInput.value
     yearInput.dispatchEvent(new MonthYearEvent({ year: parseInt(newYear, 10) }))

--- a/tests/example.spec.ts
+++ b/tests/example.spec.ts
@@ -1,38 +1,18 @@
-import { Browser, chromium, firefox, Page, webkit } from "playwright";
-import { afterAll, beforeAll, describe, it } from "vitest";
 import { test, expect } from '@playwright/test';
 
+test('has title', async ({ page }) => {
+  await page.goto('/');
 
-const browserTypes = process.env.ALL_BROWSERS
-  ? [chromium, firefox, webkit]
-  : [chromium];
+  // Expect a title "to contain" a substring.
+  await expect(page.getByTestId('input')).toHaveAttribute('id', 'input');
+});
 
-for (const browserType of browserTypes) {
-  describe(`browser:${browserType.name()}`, () => {
-    let browser: Browser;
-    let page: Page;
+// test('get started link', async ({ page }) => {
+//   await page.goto('https://playwright.dev/');
 
-    beforeAll(async () => {
-      browser = await browserType.launch({ headless: true });
-      const page = await browser.newPage();
-      page.on("console", (msg) => console.log(msg.text()));
-      await page.goto("http://localhost:5173");
-    });
+//   // Click the get started link.
+//   await page.getByRole('link', { name: 'Get started' }).click();
 
-    afterAll(async () => {
-      browser?.close();
-    });
-    it("evaluate with vite module", async () => {
-      await expect(page.getByTestId('input')).toHaveText('aaa');
-      
-      // await page.locator("#ready").waitFor({ state: "attached" });
-      // await page.evaluate(() => {
-      //   return new Promise(async (r) => {
-      //     const mod = await new Function("return import('/mod.ts')")();
-      //     console.log("hello in eval", Object.keys(mod));
-      //     r(null);
-      //   });
-      // });
-    });
-  });
-}
+//   // Expects the URL to contain intro.
+//   await expect(page).toHaveURL(/.*intro/);
+// });

--- a/tests/example.spec.ts
+++ b/tests/example.spec.ts
@@ -1,18 +1,30 @@
-import { test, expect } from '@playwright/test';
+import { test, expect, Page } from '@playwright/test';
 
-test('has title', async ({ page }) => {
+test.beforeEach(async ({ page }) => {
   await page.goto('/');
-
-  // Expect a title "to contain" a substring.
-  await expect(page.getByTestId('input')).toHaveAttribute('id', 'input');
 });
 
-// test('get started link', async ({ page }) => {
-//   await page.goto('https://playwright.dev/');
+test('is visible & hidden when clicking on input', async ({ page }) => {
+  // input is set as refElement for the datetime-web-component
+  await page.locator('#input').click();
+  await expect(page.locator('datetime-web-component')).toBeVisible();
+  await page.locator('#input').click();
+  await expect(page.locator('datetime-web-component')).toBeHidden();
+});
 
-//   // Click the get started link.
-//   await page.getByRole('link', { name: 'Get started' }).click();
+test('is visible & hidden when clicking on input and on document', async ({ page }) => {
+  await page.locator('#input').click();
+  await expect(page.locator('datetime-web-component')).toBeVisible();
+  await page.locator('#input').click();
+  await expect(page.locator('datetime-web-component')).toBeHidden();
+});
 
-//   // Expects the URL to contain intro.
-//   await expect(page).toHaveURL(/.*intro/);
-// });
+test('value is reflected correctly in datepicker', async ({ page }) => {
+  await page.locator('#input').click();
+  await expect(page.getByTestId('month')).toHaveText('December');
+  await expect(page.getByTestId('year')).toHaveText('2022');
+  await expect(page.getByTestId('day')).toHaveText('7');
+  await expect(page.getByTestId('hours')).toHaveValue('13');
+  await expect(page.getByTestId('minutes')).toHaveValue('12');
+  await expect(page.getByTestId('seconds')).toHaveValue('03');
+});

--- a/tests/example.spec.ts
+++ b/tests/example.spec.ts
@@ -28,3 +28,13 @@ test('value is reflected correctly in datepicker', async ({ page }) => {
   await expect(page.getByTestId('minutes')).toHaveValue('12');
   await expect(page.getByTestId('seconds')).toHaveValue('03');
 });
+
+test('weekdays are correct', async ({ page }) => {
+  await expect(page.getByTestId('header-cell').nth(0)).toHaveText('Mo');
+  await expect(page.getByTestId('header-cell').nth(1)).toHaveText('Tu');
+  await expect(page.getByTestId('header-cell').nth(2)).toHaveText('We');
+  await expect(page.getByTestId('header-cell').nth(3)).toHaveText('Th');
+  await expect(page.getByTestId('header-cell').nth(4)).toHaveText('Fr');
+  await expect(page.getByTestId('header-cell').nth(5)).toHaveText('Sa');
+  await expect(page.getByTestId('header-cell').nth(6)).toHaveText('Su');
+})

--- a/tests/example.spec.ts
+++ b/tests/example.spec.ts
@@ -1,0 +1,38 @@
+import { Browser, chromium, firefox, Page, webkit } from "playwright";
+import { afterAll, beforeAll, describe, it } from "vitest";
+import { test, expect } from '@playwright/test';
+
+
+const browserTypes = process.env.ALL_BROWSERS
+  ? [chromium, firefox, webkit]
+  : [chromium];
+
+for (const browserType of browserTypes) {
+  describe(`browser:${browserType.name()}`, () => {
+    let browser: Browser;
+    let page: Page;
+
+    beforeAll(async () => {
+      browser = await browserType.launch({ headless: true });
+      const page = await browser.newPage();
+      page.on("console", (msg) => console.log(msg.text()));
+      await page.goto("http://localhost:5173");
+    });
+
+    afterAll(async () => {
+      browser?.close();
+    });
+    it("evaluate with vite module", async () => {
+      await expect(page.getByTestId('input')).toHaveText('aaa');
+      
+      // await page.locator("#ready").waitFor({ state: "attached" });
+      // await page.evaluate(() => {
+      //   return new Promise(async (r) => {
+      //     const mod = await new Function("return import('/mod.ts')")();
+      //     console.log("hello in eval", Object.keys(mod));
+      //     r(null);
+      //   });
+      // });
+    });
+  });
+}

--- a/tests/example.spec.ts
+++ b/tests/example.spec.ts
@@ -1,29 +1,28 @@
-import { test, expect, Page } from '@playwright/test';
+import { test, expect } from '@playwright/test';
+import type DatetimeWebComponent from '../src/components/DatetimeWebComponent'
 
 test.beforeEach(async ({ page }) => {
   await page.goto('/');
+  // input is set as refElement for the datetime-web-component
+  await page.locator('#input').click();
 });
 
 test('is visible & hidden when clicking on input', async ({ page }) => {
-  // input is set as refElement for the datetime-web-component
-  await page.locator('#input').click();
   await expect(page.locator('datetime-web-component')).toBeVisible();
   await page.locator('#input').click();
   await expect(page.locator('datetime-web-component')).toBeHidden();
 });
 
 test('is visible & hidden when clicking on input and on document', async ({ page }) => {
-  await page.locator('#input').click();
   await expect(page.locator('datetime-web-component')).toBeVisible();
   await page.locator('#input').click();
   await expect(page.locator('datetime-web-component')).toBeHidden();
 });
 
 test('value is reflected correctly in datepicker', async ({ page }) => {
-  await page.locator('#input').click();
   await expect(page.getByTestId('month')).toHaveText('December');
   await expect(page.getByTestId('year')).toHaveText('2022');
-  await expect(page.getByTestId('day')).toHaveText('7');
+  await expect(page.getByTestId('selected-cell')).toHaveText('7');
   await expect(page.getByTestId('hours')).toHaveValue('13');
   await expect(page.getByTestId('minutes')).toHaveValue('12');
   await expect(page.getByTestId('seconds')).toHaveValue('03');
@@ -37,4 +36,47 @@ test('weekdays are correct', async ({ page }) => {
   await expect(page.getByTestId('header-cell').nth(4)).toHaveText('Fr');
   await expect(page.getByTestId('header-cell').nth(5)).toHaveText('Sa');
   await expect(page.getByTestId('header-cell').nth(6)).toHaveText('Su');
+})
+
+test('correct amount of inactive cells', async ({ page }) => {
+  await expect(page.getByTestId('inactive-cell')).toHaveCount(3);
+  page.getByTestId('next-month').click();
+  await expect(page.getByTestId('inactive-cell')).toHaveCount(6);
+})
+
+test('can toggle through months', async ({ page }) => {
+  page.getByTestId('previous-month').click()
+  await expect(page.getByTestId('month')).toHaveText('November')
+  page.getByTestId('next-month').click()
+  page.getByTestId('next-month').click()
+  await expect(page.getByTestId('month')).toHaveText('January')
+  await expect(page.getByTestId('year')).toHaveText('2023')
+})
+
+test('correct days are blocked', async ({ page }) => {
+  const blockedDays = [2, 6, 9, 13, 16, 20, 23, 27, 30];
+  await expect(page.getByTestId('blocked-cell').nth(0)).toHaveText(blockedDays[0].toString());
+  await expect(page.getByTestId('blocked-cell').nth(1)).toHaveText(blockedDays[1].toString());
+  await expect(page.getByTestId('blocked-cell').nth(2)).toHaveText(blockedDays[2].toString());
+  await expect(page.getByTestId('blocked-cell').nth(3)).toHaveText(blockedDays[3].toString());
+  await expect(page.getByTestId('blocked-cell').nth(4)).toHaveText(blockedDays[4].toString());
+  await expect(page.getByTestId('blocked-cell').nth(5)).toHaveText(blockedDays[5].toString());
+  await expect(page.getByTestId('blocked-cell').nth(6)).toHaveText(blockedDays[6].toString());
+  await expect(page.getByTestId('blocked-cell').nth(7)).toHaveText(blockedDays[7].toString());
+  await expect(page.getByTestId('blocked-cell').nth(8)).toHaveText(blockedDays[8].toString());
+
+
+  const datetimeWebComponentHandle = await page.$('datetime-web-component');
+  await page.evaluate(datetimeWebComponentHandle => { 
+    if (datetimeWebComponentHandle) {
+      (datetimeWebComponentHandle as DatetimeWebComponent).isDayBlocked = (value: Date) => {
+        return value.getMonth() === 0
+      }
+    }
+   
+  }, datetimeWebComponentHandle);
+
+  await expect(page.getByTestId('blocked-cell')).toHaveCount(0);
+  page.getByTestId('next-month').click();
+  await expect(page.getByTestId('blocked-cell')).toHaveCount(31);
 })

--- a/tests/example.spec.ts
+++ b/tests/example.spec.ts
@@ -155,7 +155,7 @@ test('increasing seconds to above 60 increments the minutes', async ({
   await expect(page.getByTestId('minutes')).toHaveValue('13')
 })
 
-test('selecting date updates the input', async ({ page }) => {
+test('selecting date updates the input value', async ({ page }) => {
   await page.getByTestId('next-month').click()
   await page.getByTestId('default-cell').nth(11).click()
   await page.getByTestId('hours').fill('5')

--- a/tests/example.spec.ts
+++ b/tests/example.spec.ts
@@ -53,7 +53,7 @@ test('can toggle through months', async ({ page }) => {
   await expect(page.getByTestId('year')).toHaveText('2023')
 })
 
-test('correct days are blocked', async ({ page }) => {
+test('blocks the correct days', async ({ page }) => {
   const blockedDays = [2, 6, 9, 13, 16, 20, 23, 27, 30];
   await expect(page.getByTestId('blocked-cell').nth(0)).toHaveText(blockedDays[0].toString());
   await expect(page.getByTestId('blocked-cell').nth(1)).toHaveText(blockedDays[1].toString());
@@ -64,7 +64,6 @@ test('correct days are blocked', async ({ page }) => {
   await expect(page.getByTestId('blocked-cell').nth(6)).toHaveText(blockedDays[6].toString());
   await expect(page.getByTestId('blocked-cell').nth(7)).toHaveText(blockedDays[7].toString());
   await expect(page.getByTestId('blocked-cell').nth(8)).toHaveText(blockedDays[8].toString());
-
 
   const datetimeWebComponentHandle = await page.$('datetime-web-component');
   await page.evaluate(datetimeWebComponentHandle => { 

--- a/tests/example.spec.ts
+++ b/tests/example.spec.ts
@@ -1,47 +1,49 @@
-import { test, expect } from '@playwright/test';
+import { test, expect } from '@playwright/test'
 import type DatetimeWebComponent from '../src/components/DatetimeWebComponent'
 
 test.beforeEach(async ({ page }) => {
-  await page.goto('/');
+  await page.goto('/')
   // input is set as refElement for the datetime-web-component
-  await page.locator('#input').click();
-});
+  await page.getByTestId('input').click()
+})
 
 test('is visible & hidden when clicking on input', async ({ page }) => {
-  await expect(page.locator('datetime-web-component')).toBeVisible();
-  await page.locator('#input').click();
-  await expect(page.locator('datetime-web-component')).toBeHidden();
-});
+  await expect(page.locator('datetime-web-component')).toBeVisible()
+  await page.getByTestId('input').click()
+  await expect(page.locator('datetime-web-component')).toBeHidden()
+})
 
-test('is visible & hidden when clicking on input and on document', async ({ page }) => {
-  await expect(page.locator('datetime-web-component')).toBeVisible();
-  await page.locator('#input').click();
-  await expect(page.locator('datetime-web-component')).toBeHidden();
-});
+test('is visible & hidden when clicking on input and on document', async ({
+  page,
+}) => {
+  await expect(page.locator('datetime-web-component')).toBeVisible()
+  await page.getByTestId('input').click()
+  await expect(page.locator('datetime-web-component')).toBeHidden()
+})
 
 test('value is reflected correctly in datepicker', async ({ page }) => {
-  await expect(page.getByTestId('month')).toHaveText('December');
-  await expect(page.getByTestId('year')).toHaveText('2022');
-  await expect(page.getByTestId('selected-cell')).toHaveText('7');
-  await expect(page.getByTestId('hours')).toHaveValue('13');
-  await expect(page.getByTestId('minutes')).toHaveValue('12');
-  await expect(page.getByTestId('seconds')).toHaveValue('03');
-});
+  await expect(page.getByTestId('month')).toHaveText('December')
+  await expect(page.getByTestId('year')).toHaveText('2022')
+  await expect(page.getByTestId('selected-cell')).toHaveText('7')
+  await expect(page.getByTestId('hours')).toHaveValue('13')
+  await expect(page.getByTestId('minutes')).toHaveValue('12')
+  await expect(page.getByTestId('seconds')).toHaveValue('03')
+})
 
 test('weekdays are correct', async ({ page }) => {
-  await expect(page.getByTestId('header-cell').nth(0)).toHaveText('Mo');
-  await expect(page.getByTestId('header-cell').nth(1)).toHaveText('Tu');
-  await expect(page.getByTestId('header-cell').nth(2)).toHaveText('We');
-  await expect(page.getByTestId('header-cell').nth(3)).toHaveText('Th');
-  await expect(page.getByTestId('header-cell').nth(4)).toHaveText('Fr');
-  await expect(page.getByTestId('header-cell').nth(5)).toHaveText('Sa');
-  await expect(page.getByTestId('header-cell').nth(6)).toHaveText('Su');
+  await expect(page.getByTestId('header-cell').nth(0)).toHaveText('Mo')
+  await expect(page.getByTestId('header-cell').nth(1)).toHaveText('Tu')
+  await expect(page.getByTestId('header-cell').nth(2)).toHaveText('We')
+  await expect(page.getByTestId('header-cell').nth(3)).toHaveText('Th')
+  await expect(page.getByTestId('header-cell').nth(4)).toHaveText('Fr')
+  await expect(page.getByTestId('header-cell').nth(5)).toHaveText('Sa')
+  await expect(page.getByTestId('header-cell').nth(6)).toHaveText('Su')
 })
 
 test('correct amount of inactive cells', async ({ page }) => {
-  await expect(page.getByTestId('inactive-cell')).toHaveCount(3);
-  page.getByTestId('next-month').click();
-  await expect(page.getByTestId('inactive-cell')).toHaveCount(6);
+  await expect(page.getByTestId('inactive-cell')).toHaveCount(3)
+  page.getByTestId('next-month').click()
+  await expect(page.getByTestId('inactive-cell')).toHaveCount(6)
 })
 
 test('can toggle through months', async ({ page }) => {
@@ -54,47 +56,112 @@ test('can toggle through months', async ({ page }) => {
 })
 
 test('blocks the correct days', async ({ page }) => {
-  const blockedDays = [2, 6, 9, 13, 16, 20, 23, 27, 30];
-  await expect(page.getByTestId('blocked-cell').nth(0)).toHaveText(blockedDays[0].toString());
-  await expect(page.getByTestId('blocked-cell').nth(1)).toHaveText(blockedDays[1].toString());
-  await expect(page.getByTestId('blocked-cell').nth(2)).toHaveText(blockedDays[2].toString());
-  await expect(page.getByTestId('blocked-cell').nth(3)).toHaveText(blockedDays[3].toString());
-  await expect(page.getByTestId('blocked-cell').nth(4)).toHaveText(blockedDays[4].toString());
-  await expect(page.getByTestId('blocked-cell').nth(5)).toHaveText(blockedDays[5].toString());
-  await expect(page.getByTestId('blocked-cell').nth(6)).toHaveText(blockedDays[6].toString());
-  await expect(page.getByTestId('blocked-cell').nth(7)).toHaveText(blockedDays[7].toString());
-  await expect(page.getByTestId('blocked-cell').nth(8)).toHaveText(blockedDays[8].toString());
+  const blockedDays = [2, 6, 9, 13, 16, 20, 23, 27, 30]
+  await expect(page.getByTestId('blocked-cell').nth(0)).toHaveText(
+    blockedDays[0].toString()
+  )
+  await expect(page.getByTestId('blocked-cell').nth(1)).toHaveText(
+    blockedDays[1].toString()
+  )
+  await expect(page.getByTestId('blocked-cell').nth(2)).toHaveText(
+    blockedDays[2].toString()
+  )
+  await expect(page.getByTestId('blocked-cell').nth(3)).toHaveText(
+    blockedDays[3].toString()
+  )
+  await expect(page.getByTestId('blocked-cell').nth(4)).toHaveText(
+    blockedDays[4].toString()
+  )
+  await expect(page.getByTestId('blocked-cell').nth(5)).toHaveText(
+    blockedDays[5].toString()
+  )
+  await expect(page.getByTestId('blocked-cell').nth(6)).toHaveText(
+    blockedDays[6].toString()
+  )
+  await expect(page.getByTestId('blocked-cell').nth(7)).toHaveText(
+    blockedDays[7].toString()
+  )
+  await expect(page.getByTestId('blocked-cell').nth(8)).toHaveText(
+    blockedDays[8].toString()
+  )
 
-  const handle = await page.$('datetime-web-component');
+  const handle = await page.$('datetime-web-component')
   if (handle) {
-    await handle.evaluate(handle => { 
-      (handle as DatetimeWebComponent).isDayBlocked = (value: Date) => {
+    await handle.evaluate((handle) => {
+      ;(handle as DatetimeWebComponent).isDayBlocked = (value: Date) => {
         return value.getMonth() === 0
       }
-    });
+    })
   }
 
-  await expect(page.getByTestId('blocked-cell')).toHaveCount(0);
-  page.getByTestId('next-month').click();
-  await expect(page.getByTestId('blocked-cell')).toHaveCount(31);
+  await expect(page.getByTestId('blocked-cell')).toHaveCount(0)
+  page.getByTestId('next-month').click()
+  await expect(page.getByTestId('blocked-cell')).toHaveCount(31)
 })
 
-test('hides seconds if showSeconds is false', async ({page}) => {
-  const handle = await page.$('datetime-web-component');
+test('hides seconds if showSeconds is false', async ({ page }) => {
+  const handle = await page.$('datetime-web-component')
   if (handle) {
-    await handle.evaluate(handle => { 
-      (handle as DatetimeWebComponent).showSeconds = false
-    });
+    await handle.evaluate((handle) => {
+      ;(handle as DatetimeWebComponent).showSeconds = false
+    })
   }
-  await expect(page.getByTestId('seconds')).toHaveCount(0);
+  await expect(page.getByTestId('seconds')).toHaveCount(0)
 })
 
-test('hides time input if onlyDate is true', async ({page}) => {
-  const handle = await page.$('datetime-web-component');
+test('hides time input if onlyDate is true', async ({ page }) => {
+  const handle = await page.$('datetime-web-component')
   if (handle) {
-    await handle.evaluate(handle => { 
-      (handle as DatetimeWebComponent).onlyDate = true
-    });
+    await handle.evaluate((handle) => {
+      ;(handle as DatetimeWebComponent).onlyDate = true
+    })
   }
-  await expect(page.getByTestId('time-container')).toHaveCount(0);
+  await expect(page.getByTestId('time-container')).toHaveCount(0)
+})
+
+test('can switch to any month', async ({ page }) => {
+  await page.getByTestId('month').click()
+  await expect(page.getByTestId('month-cell')).toHaveCount(12)
+  const november = page.getByTestId('month-cell').nth(10)
+  await expect(november).toHaveText('November')
+  await november.click()
+  await expect(page.getByTestId('month')).toHaveText('November')
+})
+
+test('can switch to any year', async ({ page }) => {
+  await page.getByTestId('year').click()
+  await page.getByTestId('year-input').fill('2023')
+  await page.getByTestId('confirm-year').click()
+  await expect(page.getByTestId('year')).toHaveText('2023')
+  await expect(page.getByTestId('inactive-cell')).toHaveCount(4)
+})
+
+test('increasing hour from 23 to 24 increments the day', async ({ page }) => {
+  await page.getByTestId('hours').fill('24')
+  await expect(page.getByTestId('selected-cell')).toHaveText('8')
+})
+
+test('increasing minutes to above 60 increments the hours', async ({
+  page,
+}) => {
+  await page.getByTestId('minutes').fill('60')
+  await expect(page.getByTestId('hours')).toHaveValue('14')
+})
+
+test('increasing seconds to above 60 increments the minutes', async ({
+  page,
+}) => {
+  await page.getByTestId('seconds').fill('60')
+  await expect(page.getByTestId('minutes')).toHaveValue('13')
+})
+
+test('selecting date updates the input', async ({ page }) => {
+  await page.getByTestId('next-month').click()
+  await page.getByTestId('default-cell').nth(11).click()
+  await page.getByTestId('hours').fill('5')
+  await page.getByTestId('minutes').fill('45')
+  await page.getByTestId('seconds').fill('23')
+  await expect(page.getByTestId('input')).toHaveValue(
+    '2023-01-16T04:45:23.000Z'
+  )
 })

--- a/tests/example.spec.ts
+++ b/tests/example.spec.ts
@@ -65,17 +65,36 @@ test('blocks the correct days', async ({ page }) => {
   await expect(page.getByTestId('blocked-cell').nth(7)).toHaveText(blockedDays[7].toString());
   await expect(page.getByTestId('blocked-cell').nth(8)).toHaveText(blockedDays[8].toString());
 
-  const datetimeWebComponentHandle = await page.$('datetime-web-component');
-  await page.evaluate(datetimeWebComponentHandle => { 
-    if (datetimeWebComponentHandle) {
-      (datetimeWebComponentHandle as DatetimeWebComponent).isDayBlocked = (value: Date) => {
+  const handle = await page.$('datetime-web-component');
+  if (handle) {
+    await handle.evaluate(handle => { 
+      (handle as DatetimeWebComponent).isDayBlocked = (value: Date) => {
         return value.getMonth() === 0
       }
-    }
-   
-  }, datetimeWebComponentHandle);
+    });
+  }
 
   await expect(page.getByTestId('blocked-cell')).toHaveCount(0);
   page.getByTestId('next-month').click();
   await expect(page.getByTestId('blocked-cell')).toHaveCount(31);
+})
+
+test('hides seconds if showSeconds is false', async ({page}) => {
+  const handle = await page.$('datetime-web-component');
+  if (handle) {
+    await handle.evaluate(handle => { 
+      (handle as DatetimeWebComponent).showSeconds = false
+    });
+  }
+  await expect(page.getByTestId('seconds')).toHaveCount(0);
+})
+
+test('hides time input if onlyDate is true', async ({page}) => {
+  const handle = await page.$('datetime-web-component');
+  if (handle) {
+    await handle.evaluate(handle => { 
+      (handle as DatetimeWebComponent).onlyDate = true
+    });
+  }
+  await expect(page.getByTestId('time-container')).toHaveCount(0);
 })

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -12,4 +12,7 @@ export default defineConfig({
       output: {},
     },
   },
+  test: {
+    globals: true
+  }
 })

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -12,7 +12,4 @@ export default defineConfig({
       output: {},
     },
   },
-  test: {
-    globals: true
-  }
 })


### PR DESCRIPTION
This PR will add tests for the following functionality:
- datetime-web-component is made visible and hidden when clicking on `refElement` and clicking on it again
- datetime-web-component is made visible and hidden when clicking on `refElemeng` and clicking on somewhere outside the datetime-web-component (body)
- value programmatically given to datetime-web-component is correctly reflected in its UI
- all the weekdays are correctly set
- a month has the correct amount of inactive cells (offset as first day of the month isn't necessarily Monday)
- can go to next and previous months by using arrow buttons
- the correct days are blocked with the `isDayBlocked` function
- seconds are hidden if `showSeconds` is set to false
- the time picker is hidden if `onlyDate` is set to true
- can switch to a month by clicking on a month in the overview
- can switch to a year by setting the year value and confirming
- increasing hour from 23 to 24 increments the day
- increasing minutes to above 60 increments the hours
- increasing seconds to above 60 increments the minutes
- selecting date updates the input value

This PR will also add a github workflow for the playwright tests.